### PR TITLE
Formatting - used the dbatools formatter

### DIFF
--- a/source/Public/Capacity/Get-FabricCapacities.ps1
+++ b/source/Public/Capacity/Get-FabricCapacities.ps1
@@ -49,8 +49,7 @@ function Get-FabricCapacities {
             # Get all resources of type "Microsoft.Fabric/capacities" and add them to the results array
             $res += Get-AzResource -ResourceGroupName $r.ResourceGroupName -resourcetype "Microsoft.Fabric/capacities" -ErrorAction SilentlyContinue
         }
-    }
-    else {
+    } else {
         # If no subscription ID is provided, get all subscriptions
         $subscriptions = Get-AzSubscription
 

--- a/source/Public/Capacity/Get-FabricCapacity.ps1
+++ b/source/Public/Capacity/Get-FabricCapacity.ps1
@@ -49,44 +49,40 @@ function Get-FabricCapacity {
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
- 
+
         # Construct the API endpoint URL
         $apiEndpointURI = "{0}/capacities" -f $FabricConfig.BaseUrl
-        
+
         # Invoke the Fabric API to retrieve capacity details
         $capacities = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
             -Method Get
 
- 
+
         # Filter results based on provided parameters
         $response = if ($capacityId) {
             $capacities | Where-Object { $_.Id -eq $capacityId }
-        }
-        elseif ($capacityName) {
+        } elseif ($capacityName) {
             $capacities | Where-Object { $_.DisplayName -eq $capacityName }
-        }
-        else {
+        } else {
             # No filter, return all capacities
             Write-Message -Message "No filter specified. Returning all capacities." -Level Debug
             return $capacities
         }
- 
+
         # Handle results
         if ($response) {
             Write-Message -Message "Capacity found matching the specified criteria." -Level Debug
             return $response
-        }
-        else {
+        } else {
             Write-Message -Message "No capacity found matching the specified criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve capacity. Error: $errorDetails" -Level Error
         return $null
     }
-} 
+}

--- a/source/Public/Capacity/Get-FabricCapacityRefreshables.ps1
+++ b/source/Public/Capacity/Get-FabricCapacityRefreshables.ps1
@@ -1,5 +1,5 @@
-function Get-FabricCapacityRefreshables  {
-<#
+function Get-FabricCapacityRefreshables {
+    <#
 .SYNOPSIS
 Retrieves the top refreshable capacities for the tenant.
 
@@ -16,15 +16,15 @@ This example retrieves the top 5 refreshable capacities for the tenant.
 
 .NOTES
 The function retrieves the PowerBI access token and makes a GET request to the PowerBI API to retrieve the top refreshable capacities. It then returns the 'value' property of the response, which contains the capacities.
-#>
+    #>
 
-# This function retrieves the top refreshable capacities for the tenant.
+    # This function retrieves the top refreshable capacities for the tenant.
     # Define aliases for the function for flexibility.
     [Alias("Get-FabCapacityRefreshables")]
 
     # Define a mandatory parameter for the number of top refreshable capacities to retrieve.
     Param (
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$top = 5
     )
 

--- a/source/Public/Capacity/Get-FabricCapacitySkus.ps1
+++ b/source/Public/Capacity/Get-FabricCapacitySkus.ps1
@@ -1,6 +1,6 @@
 
-function Get-FabricCapacitySkus  {
-<#
+function Get-FabricCapacitySkus {
+    <#
 .SYNOPSIS
 Retrieves the fabric capacity information.
 
@@ -19,7 +19,7 @@ Specifies the capacity to retrieve information for. If not provided, all capacit
 .EXAMPLE
 Get-FabricCapacitySkus -capacity "exampleCapacity"
 Retrieves the fabric capacity information for the specified capacity.
-#>
+    #>
     # Define aliases for the function for flexibility.
 
     Param(
@@ -27,7 +27,7 @@ Retrieves the fabric capacity information for the specified capacity.
         [string]$subscriptionID,
         [Parameter(Mandatory = $true)]
         [string]$ResourceGroupName,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$capacity
     )
 

--- a/source/Public/Capacity/Get-FabricCapacityState.ps1
+++ b/source/Public/Capacity/Get-FabricCapacityState.ps1
@@ -1,5 +1,5 @@
 function Get-FabricCapacityState {
-<#
+    <#
 .SYNOPSIS
 Retrieves the state of a specific capacity.
 
@@ -22,19 +22,19 @@ This example retrieves the state of a specific capacity given the subscription I
 
 .NOTES
 The function checks if the Azure token is null. If it is, it connects to the Azure account and retrieves the token. It then defines the headers for the GET request and the URL for the GET request. Finally, it makes the GET request and returns the response.
-#>
+    #>
 
-# This function retrieves the state of a specific capacity.
+    # This function retrieves the state of a specific capacity.
     # Define aliases for the function for flexibility.
     [Alias("Get-FabCapacityState")]
 
     # Define mandatory parameters for the subscription ID, resource group, and capacity.
     Param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$subscriptionID,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$resourcegroup,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$capacity
     )
 

--- a/source/Public/Capacity/Get-FabricCapacityTenantOverrides.ps1
+++ b/source/Public/Capacity/Get-FabricCapacityTenantOverrides.ps1
@@ -1,5 +1,5 @@
-function Get-FabricCapacityTenantOverrides  {
-<#
+function Get-FabricCapacityTenantOverrides {
+    <#
 .SYNOPSIS
 Retrieves the tenant overrides for all capacities.
 
@@ -16,9 +16,9 @@ This example retrieves the tenant overrides for all capacities.
 
 .NOTES
 The function retrieves the PowerBI access token and makes a GET request to the Fabric API to retrieve the tenant overrides for all capacities. It then returns the response of the GET request.
-#>
+    #>
 
-# This function retrieves the tenant overrides for all capacities.
+    # This function retrieves the tenant overrides for all capacities.
     # Define aliases for the function for flexibility.
     [Alias("Get-FabCapacityTenantOverrides")]
 

--- a/source/Public/Capacity/Get-FabricCapacityWorkload.ps1
+++ b/source/Public/Capacity/Get-FabricCapacityWorkload.ps1
@@ -1,4 +1,4 @@
-function Get-FabricCapacityWorkload  {
+function Get-FabricCapacityWorkload {
     <#
 .SYNOPSIS
 Retrieves the workloads for a specific capacity.
@@ -19,15 +19,15 @@ This example retrieves the workloads for a specific capacity given the capacity 
 
 .NOTES
 The function retrieves the PowerBI access token and makes a GET request to the PowerBI API to retrieve the workloads for the specified capacity. It then returns the 'value' property of the response, which contains the workloads.
-#>
+    #>
 
-# This function retrieves the workloads for a specific capacity.
+    # This function retrieves the workloads for a specific capacity.
     # Define aliases for the function for flexibility.
     [Alias("Get-FabCapacityWorkload")]
 
     # Define a mandatory parameter for the capacity ID.
     Param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$capacityID
     )
 

--- a/source/Public/Capacity/Resume-FabricCapacity.ps1
+++ b/source/Public/Capacity/Resume-FabricCapacity.ps1
@@ -1,5 +1,5 @@
 function Resume-FabricCapacity {
-<#
+    <#
 .SYNOPSIS
 Resumes a capacity.
 
@@ -22,9 +22,9 @@ This example resumes a capacity given the subscription ID, resource group, and c
 
 .NOTES
 The function defines parameters for the subscription ID, resource group, and capacity. If the 'azToken' environment variable is null, it connects to the Azure account and sets the 'azToken' environment variable. It then defines the headers for the request, defines the URI for the request, and makes a GET request to the URI.
-#>
+    #>
 
-# This function resumes a capacity.
+    # This function resumes a capacity.
 
     # Define aliases for the function for flexibility.
     [Alias("Resume-FabCapacity")]

--- a/source/Public/Capacity/Suspend-FabricCapacity.ps1
+++ b/source/Public/Capacity/Suspend-FabricCapacity.ps1
@@ -1,6 +1,6 @@
 # This function suspends a capacity.
 function Suspend-FabricCapacity {
-<#
+    <#
 .SYNOPSIS
 Suspends a capacity.
 
@@ -23,7 +23,7 @@ This example suspends a capacity given the subscription ID, resource group, and 
 
 .NOTES
 The function defines parameters for the subscription ID, resource group, and capacity. If the 'azToken' environment variable is null, it connects to the Azure account and sets the 'azToken' environment variable. It then defines the headers for the request, defines the URI for the request, and makes a GET request to the URI.
-#>
+    #>
 
     # Define aliases for the function for flexibility.
     [Alias("Suspend-PowerBICapacity", "Suspend-FabCapacity")]

--- a/source/Public/Confirm-FabricAuthToken.ps1
+++ b/source/Public/Confirm-FabricAuthToken.ps1
@@ -21,30 +21,30 @@
 #>
 
 function Confirm-FabricAuthToken {
-   [CmdletBinding()]
-   param  (   )
+    [CmdletBinding()]
+    param  (   )
 
-   Write-Verbose "Check if session is established and token not expired."
+    Write-Verbose "Check if session is established and token not expired."
 
-   # Check if the Fabric token is already set
-   if (!$FabricSession.FabricToken -or !$AzureSession.AccessToken) {
-      Write-Output "Confirm-FabricAuthToken::Set-FabricAuthToken"
-      Set-FabricAuthToken | Out-Null
-   }
+    # Check if the Fabric token is already set
+    if (!$FabricSession.FabricToken -or !$AzureSession.AccessToken) {
+        Write-Output "Confirm-FabricAuthToken::Set-FabricAuthToken"
+        Set-FabricAuthToken | Out-Null
+    }
 
-   $now = (Get-Date)
-   $s = Get-FabricDebugInfo
-   if ($FabricSession.AccessToken.ExpiresOn -lt $now ) {
-      Write-Output "Confirm-FabricAuthToken::Set-FabricAuthToken#1"
-      Set-FabricAuthToken -reset | Out-Null
-   }
+    $now = (Get-Date)
+    $s = Get-FabricDebugInfo
+    if ($FabricSession.AccessToken.ExpiresOn -lt $now ) {
+        Write-Output "Confirm-FabricAuthToken::Set-FabricAuthToken#1"
+        Set-FabricAuthToken -reset | Out-Null
+    }
 
-   if ($s.AzureSession.AccessToken.ExpiresOn -lt $now ) {
-      Write-Output "Confirm-FabricAuthToken::Set-FabricAuthToken#2"
-      Set-FabricAuthToken -reset | Out-Null
-   }
+    if ($s.AzureSession.AccessToken.ExpiresOn -lt $now ) {
+        Write-Output "Confirm-FabricAuthToken::Set-FabricAuthToken#2"
+        Set-FabricAuthToken -reset | Out-Null
+    }
 
-   $s = Get-FabricDebugInfo
-   return $s
+    $s = Get-FabricDebugInfo
+    return $s
 
 }

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -1,7 +1,7 @@
 function Connect-FabricAccount {
-#Requires -Version 7.1
+    #Requires -Version 7.1
 
-<#
+    <#
 .SYNOPSIS
     Connects to the Fabric WebAPI.
 
@@ -26,31 +26,31 @@ function Connect-FabricAccount {
 .LINK
     Connect-AzAccount https://learn.microsoft.com/de-de/powershell/module/az.accounts/connect-azaccount?view=azps-12.4.0
 
-#>
+    #>
 
-[CmdletBinding()]
+    [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$TenantId
     )
 
-begin {
-}
+    begin {
+    }
 
-process {
-    Write-Verbose "Connect to Azure Account"
-    Connect-AzAccount -TenantId $TenantId | Out-Null
+    process {
+        Write-Verbose "Connect to Azure Account"
+        Connect-AzAccount -TenantId $TenantId | Out-Null
 
-    Write-Verbose "Get authentication token"
-    $FabricSession.FabricToken = (Get-AzAccessToken -ResourceUrl $FabricSession.BaseApiUrl).Token
-    Write-Verbose "Token: $($FabricSession.FabricToken)"
+        Write-Verbose "Get authentication token"
+        $FabricSession.FabricToken = (Get-AzAccessToken -ResourceUrl $FabricSession.BaseApiUrl).Token
+        Write-Verbose "Token: $($FabricSession.FabricToken)"
 
-    Write-Verbose "Setup headers for API calls"
-    $FabricSession.HeaderParams = @{'Authorization'="Bearer {0}" -f $FabricSession.FabricToken}
-    Write-Verbose "HeaderParams: $($FabricSession.HeaderParams)"
-}
+        Write-Verbose "Setup headers for API calls"
+        $FabricSession.HeaderParams = @{'Authorization' = "Bearer {0}" -f $FabricSession.FabricToken }
+        Write-Verbose "HeaderParams: $($FabricSession.HeaderParams)"
+    }
 
-end {
-}
+    end {
+    }
 
 }

--- a/source/Public/Copy Job/Get-FabricCopyJob.ps1
+++ b/source/Public/Copy Job/Get-FabricCopyJob.ps1
@@ -1,5 +1,5 @@
 function Get-FabricCopyJob {
-<#
+    <#
 .SYNOPSIS
     Retrieves CopyJob details from a specified Microsoft Fabric workspace.
 
@@ -29,7 +29,7 @@ function Get-FabricCopyJob {
     Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -63,19 +63,17 @@ function Get-FabricCopyJob {
         $apiEndpointURI = "{0}/workspaces/{1}/copyJobs" -f $FabricConfig.BaseUrl, $WorkspaceId
 
         # Invoke the Fabric API to retrieve capacity details
-        $copyJobs =  Invoke-FabricAPIRequest `
-        -BaseURI $apiEndpointURI `
-        -Headers $FabricConfig.FabricHeaders `
-        -Method Get
+        $copyJobs = Invoke-FabricAPIRequest `
+            -BaseURI $apiEndpointURI `
+            -Headers $FabricConfig.FabricHeaders `
+            -Method Get
 
         #  Filter results based on provided parameters
         $response = if ($CopyJobId) {
             $copyJobs | Where-Object { $_.Id -eq $CopyJobId }
-        }
-        elseif ($CopyJobName) {
+        } elseif ($CopyJobName) {
             $copyJobs | Where-Object { $_.DisplayName -eq $CopyJobName }
-        }
-        else {
+        } else {
             # Return all CopyJobs if no filter is provided
             Write-Message -Message "No filter provided. Returning all CopyJobs." -Level Debug
             $copyJobs
@@ -85,13 +83,11 @@ function Get-FabricCopyJob {
         if ($response) {
             Write-Message -Message "CopyJob found matching the specified criteria." -Level Debug
             return $response
-        }
-        else {
+        } else {
             Write-Message -Message "No CopyJob found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve CopyJob. Error: $errorDetails" -Level Error

--- a/source/Public/Copy Job/Get-FabricCopyJob.ps1
+++ b/source/Public/Copy Job/Get-FabricCopyJob.ps1
@@ -17,11 +17,11 @@ function Get-FabricCopyJob {
     The name of the CopyJob to retrieve. This parameter is optional.
 
 .EXAMPLE
-     FabricCopyJob -WorkspaceId "workspace-12345" -CopyJobId "CopyJob-67890"
+    FabricCopyJob -WorkspaceId "workspace-12345" -CopyJobId "CopyJob-67890"
     This example retrieves the CopyJob details for the CopyJob with ID "CopyJob-67890" in the workspace with ID "workspace-12345".
 
 .EXAMPLE
-     FabricCopyJob -WorkspaceId "workspace-12345" -CopyJobName "My CopyJob"
+    FabricCopyJob -WorkspaceId "workspace-12345" -CopyJobName "My CopyJob"
     This example retrieves the CopyJob details for the CopyJob named "My CopyJob" in the workspace with ID "workspace-12345".
 
 .NOTES

--- a/source/Public/Copy Job/Get-FabricCopyJob.ps1
+++ b/source/Public/Copy Job/Get-FabricCopyJob.ps1
@@ -4,7 +4,7 @@ function Get-FabricCopyJob {
     Retrieves CopyJob details from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function retrieves CopyJob details from a specified workspace using either the provided CopyJobId or CopyJobName.
+    This function retrieves CopyJob details from a specified workspace using either the provided CopyJobId or CopyJob.
     It handles token validation, constructs the API URL, makes the API request, and processes the response.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@ function Get-FabricCopyJob {
     This example retrieves the CopyJob details for the CopyJob with ID "CopyJob-67890" in the workspace with ID "workspace-12345".
 
 .EXAMPLE
-    FabricCopyJob -WorkspaceId "workspace-12345" -CopyJobName "My CopyJob"
+    FabricCopyJob -WorkspaceId "workspace-12345" -CopyJob "My CopyJob"
     This example retrieves the CopyJob details for the CopyJob named "My CopyJob" in the workspace with ID "workspace-12345".
 
 .NOTES
@@ -48,8 +48,8 @@ function Get-FabricCopyJob {
 
     try {
         # Handle ambiguous input
-        if ($CopyJobId -and $CopyJobName) {
-            Write-Message -Message "Both 'CopyJobId' and 'CopyJobName' were provided. Please specify only one." -Level Error
+        if ($CopyJobId -and $CopyJob) {
+            Write-Message -Message "Both 'CopyJobId' and 'CopyJob' were provided. Please specify only one." -Level Error
             return $null
         }
 
@@ -71,8 +71,8 @@ function Get-FabricCopyJob {
         #  Filter results based on provided parameters
         $response = if ($CopyJobId) {
             $copyJobs | Where-Object { $_.Id -eq $CopyJobId }
-        } elseif ($CopyJobName) {
-            $copyJobs | Where-Object { $_.DisplayName -eq $CopyJobName }
+        } elseif ($CopyJob) {
+            $copyJobs | Where-Object { $_.DisplayName -eq $CopyJob }
         } else {
             # Return all CopyJobs if no filter is provided
             Write-Message -Message "No filter provided. Returning all CopyJobs." -Level Debug

--- a/source/Public/Copy Job/Get-FabricCopyJobDefinition.ps1
+++ b/source/Public/Copy Job/Get-FabricCopyJobDefinition.ps1
@@ -3,7 +3,7 @@
 Retrieves the definition of a Copy Job from a specific workspace in Microsoft Fabric.
 
 .DESCRIPTION
-This function fetches the Copy Job's content or metadata from a workspace. 
+This function fetches the Copy Job's content or metadata from a workspace.
 It supports both synchronous and asynchronous operations, with detailed logging and error handling.
 
 .PARAMETER WorkspaceId
@@ -62,14 +62,13 @@ function Get-FabricCopyJobDefinition {
         $response = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointUrl `
             -Headers $FabricConfig.FabricHeaders `
-            -Method Post 
+            -Method Post
 
         # Step 5: Return the API response containing the Copy Job definition.
         return $response
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log detailed error information for troubleshooting.
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Copy Job definition. Error: $errorDetails" -Level Error
-    } 
+    }
 }

--- a/source/Public/Copy Job/New-FabricCopyJob.ps1
+++ b/source/Public/Copy Job/New-FabricCopyJob.ps1
@@ -49,7 +49,7 @@ function New-FabricCopyJob {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$CopyJobPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$CopyJobPathPlatformDefinition
@@ -92,8 +92,7 @@ function New-FabricCopyJob {
                     payload     = $CopyJobEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in Copy Job definition." -Level Error
                 return $null
             }
@@ -116,8 +115,7 @@ function New-FabricCopyJob {
                     payload     = $CopyJobEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -133,11 +131,10 @@ function New-FabricCopyJob {
             -Method Post `
             -Body $bodyJson
 
-        Write-Message -Message "Copy Job created successfully!" -Level Info        
+        Write-Message -Message "Copy Job created successfully!" -Level Info
         return $response
-     
-    }
-    catch {
+
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create Copy Job. Error: $errorDetails" -Level Error

--- a/source/Public/Copy Job/Remove-FabricCopyJob.ps1
+++ b/source/Public/Copy Job/Remove-FabricCopyJob.ps1
@@ -3,7 +3,7 @@
     Deletes a Copy Job from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function performs a DELETE operation on the Microsoft Fabric API to remove a Copy Job 
+    This function performs a DELETE operation on the Microsoft Fabric API to remove a Copy Job
     from the specified workspace using the provided WorkspaceId and CopyJobId parameters.
 
 .PARAMETER WorkspaceId
@@ -47,13 +47,12 @@ function Remove-FabricCopyJob {
         $response = Invoke-FabricAPIRequest `
             -Headers $FabricConfig.FabricHeaders `
             -BaseURI $apiEndpointURI `
-            -Method Delete 
-        
+            -Method Delete
+
         Write-Message -Message "Copy Job '$CopyJobId' deleted successfully from workspace '$WorkspaceId'." -Level Info
         return $response
 
-    }
-    catch {
+    } catch {
         # Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete Copy Job '$CopyJobId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Copy Job/Update-FabricCopyJob.ps1
+++ b/source/Public/Copy Job/Update-FabricCopyJob.ps1
@@ -3,7 +3,7 @@
     Updates an existing Copy Job in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    Sends a PATCH request to the Microsoft Fabric API to update an existing Copy Job 
+    Sends a PATCH request to the Microsoft Fabric API to update an existing Copy Job
     in the specified workspace. Allows updating the Copy Job's name and optionally its description.
 
 .PARAMETER WorkspaceId
@@ -33,8 +33,8 @@ function Update-FabricCopyJob {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$CopyJobId,
@@ -71,18 +71,17 @@ function Update-FabricCopyJob {
         # Convert the body to JSON
         $bodyJson = $body | ConvertTo-Json
         Write-Message -Message "Request Body: $bodyJson" -Level Debug
-        
+
         # Make the API request
         $response = Invoke-FabricAPIRequest `
             -Headers $FabricConfig.FabricHeaders `
             -BaseURI $apiEndpointURI `
             -Method Patch `
-            -Body $bodyJson 
+            -Body $bodyJson
 
         Write-Message -Message "Copy Job '$CopyJobName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Copy Job. Error: $errorDetails" -Level Error

--- a/source/Public/Copy Job/Update-FabricCopyJobDefinition.ps1
+++ b/source/Public/Copy Job/Update-FabricCopyJobDefinition.ps1
@@ -3,7 +3,7 @@
 Updates the definition of a Copy Job in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function updates the content or metadata of a Copy Job within a Microsoft Fabric workspace. 
+This function updates the content or metadata of a Copy Job within a Microsoft Fabric workspace.
 The Copy Job content and platform-specific definitions can be provided as file paths, which will be encoded as Base64 and sent in the request.
 
 .PARAMETER WorkspaceId
@@ -51,7 +51,7 @@ function Update-FabricCopyJobDefinition {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$CopyJobPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$CopyJobPathPlatformDefinition
@@ -67,7 +67,7 @@ function Update-FabricCopyJobDefinition {
         $apiEndpointUrl = "{0}/workspaces/{1}/copyJobs/{2}/updateDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $CopyJobId
 
         if ($CopyJobPathPlatformDefinition) {
-            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl 
+            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
@@ -75,12 +75,12 @@ function Update-FabricCopyJobDefinition {
         $body = @{
             definition = @{
                 parts = @()
-            } 
+            }
         }
-      
+
         if ($CopyJobPathDefinition) {
             $CopyJobEncodedContent = Convert-ToBase64 -filePath $CopyJobPathDefinition
-            
+
             if (-not [string]::IsNullOrEmpty($CopyJobEncodedContent)) {
                 # Add new part to the parts array
                 $body.definition.parts += @{
@@ -88,8 +88,7 @@ function Update-FabricCopyJobDefinition {
                     payload     = $CopyJobEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in Copy Job definition." -Level Error
                 return $null
             }
@@ -104,8 +103,7 @@ function Update-FabricCopyJobDefinition {
                     payload     = $CopyJobEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -121,12 +119,11 @@ function Update-FabricCopyJobDefinition {
             -Method Post `
             -Body $bodyJson
 
-        Write-Message -Message "Copy Job updated successfully!" -Level Info        
+        Write-Message -Message "Copy Job updated successfully!" -Level Info
         return $response
-       
-   
-    }
-    catch {
+
+
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Copy Job. Error: $errorDetails" -Level Error

--- a/source/Public/Dashboard/Get-FabricDashboard.ps1
+++ b/source/Public/Dashboard/Get-FabricDashboard.ps1
@@ -17,7 +17,7 @@
     - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-    Author: Tiago Balabuch  
+    Author: Tiago Balabuch
 #>
 
 function Get-FabricDashboard {
@@ -42,13 +42,12 @@ function Get-FabricDashboard {
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
             -Method Get
-        
+
         return $Dashboards
 
-    }
-    catch {
+    } catch {
         # Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Dashboard. Error: $errorDetails" -Level Error
-    } 
+    }
 }

--- a/source/Public/Data Pipeline/Get-FabricDataPipeline.ps1
+++ b/source/Public/Data Pipeline/Get-FabricDataPipeline.ps1
@@ -1,5 +1,5 @@
 function Get-FabricDataPipeline {
-<#
+    <#
 .SYNOPSIS
     Retrieves data pipelines from a specified Microsoft Fabric workspace.
 
@@ -29,7 +29,7 @@ function Get-FabricDataPipeline {
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -70,11 +70,9 @@ function Get-FabricDataPipeline {
         # Filter results based on provided parameters
         $response = if ($DataPipelineId) {
             $DataPipelines | Where-Object { $_.Id -eq $DataPipelineId }
-        }
-        elseif ($DataPipelineName) {
+        } elseif ($DataPipelineName) {
             $DataPipelines | Where-Object { $_.DisplayName -eq $DataPipelineName }
-        }
-        else {
+        } else {
             # Return all DataPipelines if no filter is provided
             Write-Message -Message "No filter provided. Returning all DataPipelines." -Level Debug
             $DataPipelines
@@ -84,13 +82,11 @@ function Get-FabricDataPipeline {
         if ($response) {
             Write-Message -Message "DataPipeline found matching the specified criteria." -Level Debug
             return $response
-        }
-        else {
+        } else {
             Write-Message -Message "No DataPipeline found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve DataPipeline. Error: $errorDetails" -Level Error

--- a/source/Public/Data Pipeline/New-FabricDataPipeline.ps1
+++ b/source/Public/Data Pipeline/New-FabricDataPipeline.ps1
@@ -3,8 +3,8 @@
     Creates a new DataPipeline in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a POST request to the Microsoft Fabric API to create a new DataPipeline 
-    in the specified workspace. It supports optional parameters for DataPipeline description 
+    This function sends a POST request to the Microsoft Fabric API to create a new DataPipeline
+    in the specified workspace. It supports optional parameters for DataPipeline description
     and path definitions for the DataPipeline content.
 
 .PARAMETER WorkspaceId
@@ -17,7 +17,7 @@
     An optional description for the DataPipeline.
 
 .EXAMPLE
-     New-FabricDataPipeline -WorkspaceId "workspace-12345" -DataPipelineName "New DataPipeline" 
+     New-FabricDataPipeline -WorkspaceId "workspace-12345" -DataPipelineName "New DataPipeline"
     This example creates a new DataPipeline named "New DataPipeline" in the workspace with ID "workspace-12345" and uploads the definition file from the specified path.
 
 .NOTES
@@ -72,11 +72,10 @@ function New-FabricDataPipeline {
             -Headers $FabricConfig.FabricHeaders `
             -Method Post `
             -Body $bodyJson
-    
-        Write-Message -Message "Data Pipeline created successfully!" -Level Info        
+
+        Write-Message -Message "Data Pipeline created successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create DataPipeline. Error: $errorDetails" -Level Error

--- a/source/Public/Data Pipeline/Remove-FabricDataPipeline.ps1
+++ b/source/Public/Data Pipeline/Remove-FabricDataPipeline.ps1
@@ -3,7 +3,7 @@
     Removes a DataPipeline from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove a DataPipeline 
+    This function sends a DELETE request to the Microsoft Fabric API to remove a DataPipeline
     from the specified workspace using the provided WorkspaceId and DataPipelineId.
 
 .PARAMETER WorkspaceId
@@ -48,11 +48,10 @@ function Remove-FabricDataPipeline {
         $response = Invoke-FabricAPIRequest `
             -Headers $FabricConfig.FabricHeaders `
             -BaseURI $apiEndpointURI `
-            -Method Delete 
+            -Method Delete
         Write-Message -Message "DataPipeline '$DataPipelineId' deleted successfully from workspace '$WorkspaceId'." -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete DataPipeline '$DataPipelineId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Data Pipeline/Update-FabricDataPipeline.ps1
+++ b/source/Public/Data Pipeline/Update-FabricDataPipeline.ps1
@@ -3,7 +3,7 @@
     Updates an existing DataPipeline in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing DataPipeline 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing DataPipeline
     in the specified workspace. It supports optional parameters for DataPipeline description.
 
 .PARAMETER WorkspaceId
@@ -33,8 +33,8 @@ function Update-FabricDataPipeline {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$DataPipelineId,
@@ -77,12 +77,11 @@ function Update-FabricDataPipeline {
             -Headers $FabricConfig.FabricHeaders `
             -BaseURI $apiEndpointURI `
             -Method Patch `
-            -Body $bodyJson 
-        
+            -Body $bodyJson
+
         Write-Message -Message "DataPipeline '$DataPipelineName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update DataPipeline. Error: $errorDetails" -Level Error

--- a/source/Public/Datamart/Get-FabricDatamart.ps1
+++ b/source/Public/Datamart/Get-FabricDatamart.ps1
@@ -1,5 +1,5 @@
 function Get-FabricDatamart {
-<#
+    <#
 .SYNOPSIS
     Retrieves datamarts from a specified workspace.
 
@@ -25,7 +25,7 @@ function Get-FabricDatamart {
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -51,18 +51,16 @@ function Get-FabricDatamart {
         $apiEndpointURI = "{0}/workspaces/{1}/Datamarts" -f $FabricConfig.BaseUrl, $WorkspaceId
 
         $Datamarts = = Invoke-FabricAPIRequest `
-        -BaseURI $apiEndpointURI `
-        -Headers $FabricConfig.FabricHeaders `
-        -Method Get
+            -BaseURI $apiEndpointURI `
+            -Headers $FabricConfig.FabricHeaders `
+            -Method Get
         # Step 9: Filter results based on provided parameters
 
         $response = if ($datamartId) {
             $Datamarts | Where-Object { $_.Id -eq $datamartId }
-        }
-        elseif ($datamartName) {
+        } elseif ($datamartName) {
             $Datamarts | Where-Object { $_.DisplayName -eq $datamartName }
-        }
-        else {
+        } else {
             # No filter, return all datamarts
             Write-Message -Message "No filter specified. Returning all datamarts." -Level Debug
             return $Datamarts
@@ -72,13 +70,11 @@ function Get-FabricDatamart {
         if ($response) {
             Write-Message -Message "Datamart found matching the specified criteria." -Level Debug
             return $response
-        }
-        else {
+        } else {
             Write-Message -Message "No Datamart found matching the specified criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Datamart. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Assign-FabricDomainWorkspaceByCapacity.ps1
+++ b/source/Public/Domain/Assign-FabricDomainWorkspaceByCapacity.ps1
@@ -20,7 +20,7 @@ Assigns workspaces to the domain with ID "12345" based on the specified capaciti
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch 
+Author: Tiago Balabuch
 #>
 
 function Assign-FabricDomainWorkspaceByCapacity {
@@ -44,12 +44,12 @@ function Assign-FabricDomainWorkspaceByCapacity {
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/admin/domains/{1}/assignWorkspacesByCapacities" -f $FabricConfig.BaseUrl, $DomainId
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
-        
+
         # Step 3: Construct the request body
         $body = @{
             capacitiesIds = $CapacitiesIds
         }
-      
+
         # Convert the body to JSON
         $bodyJson = $body | ConvertTo-Json -Depth 2
         Write-Message -Message "Request Body: $bodyJson" -Level Debug
@@ -78,25 +78,24 @@ function Assign-FabricDomainWorkspaceByCapacity {
 
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     return $operationStatus
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -104,8 +103,7 @@ function Assign-FabricDomainWorkspaceByCapacity {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error occurred while assigning workspaces by capacity for domain '$DomainId'. Details: $errorDetails" -Level Error

--- a/source/Public/Domain/Assign-FabricDomainWorkspaceById.ps1
+++ b/source/Public/Domain/Assign-FabricDomainWorkspaceById.ps1
@@ -44,12 +44,12 @@ function Assign-FabricDomainWorkspaceById {
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/admin/domains/{1}/assignWorkspaces" -f $FabricConfig.BaseUrl, $DomainId
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
-        
+
         # Step 3: Construct the request body
         $body = @{
             workspacesIds = $WorkspaceIds
         }
-      
+
         # Convert the body to JSON
         $bodyJson = $body | ConvertTo-Json -Depth 2
         Write-Message -Message "Request Body: $bodyJson" -Level Debug
@@ -74,8 +74,7 @@ function Assign-FabricDomainWorkspaceById {
             return $null
         }
         Write-Message -Message "Successfully assigned workspaces to the domain with ID '$DomainId'." -Level Info
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to assign workspaces to the domain with ID '$DomainId'. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Assign-FabricDomainWorkspaceByPrincipal.ps1
+++ b/source/Public/Domain/Assign-FabricDomainWorkspaceByPrincipal.ps1
@@ -12,7 +12,7 @@ The ID of the domain to which workspaces will be assigned. This parameter is man
 An array representing the principals with their `id` and `type` properties. Must contain a `principals` key with an array of objects.
 
 .EXAMPLE
-$PrincipalIds = @( 
+$PrincipalIds = @(
     @{id = "813abb4a-414c-4ac0-9c2c-bd17036fd58c";  type = "User"},
     @{id = "b5b9495c-685a-447a-b4d3-2d8e963e6288"; type = "User"}
     )
@@ -90,15 +90,14 @@ function Assign-FabricDomainWorkspaceByPrincipal {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     return $operationStatus
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return operationStatus
@@ -110,8 +109,7 @@ function Assign-FabricDomainWorkspaceByPrincipal {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to assign domain workspaces by principals. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Assign-FabricDomainWorkspaceRoleAssignment.ps1
+++ b/source/Public/Domain/Assign-FabricDomainWorkspaceRoleAssignment.ps1
@@ -27,7 +27,7 @@ Assigns the `Admins` role to the specified principals in the domain with ID "123
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch 
+Author: Tiago Balabuch
 #>
 
 function Assign-FabricDomainWorkspaceRoleAssignment {
@@ -91,10 +91,9 @@ function Assign-FabricDomainWorkspaceRoleAssignment {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-        
+
         Write-Message -Message "Bulk role assignment for domain '$DomainId' completed successfully!" -Level Info
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to bulk assign roles in domain '$DomainId'. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Get-FabricDomain.ps1
+++ b/source/Public/Domain/Get-FabricDomain.ps1
@@ -28,7 +28,7 @@ Fetches the domain with the display name "Finance".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 function Get-FabricDomain {
@@ -59,7 +59,7 @@ function Get-FabricDomain {
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
 
-        # Step 3: Construct the API URL with filtering logic        
+        # Step 3: Construct the API URL with filtering logic
         $apiEndpointUrl = "{0}/admin/domains" -f $FabricConfig.BaseUrl
         if ($NonEmptyDomainsOnly) {
             $apiEndpointUrl = "{0}?nonEmptyOnly=true" -f $apiEndpointUrl
@@ -83,7 +83,7 @@ function Get-FabricDomain {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-                    
+
         # Step 6: Handle empty response
         if (-not $response) {
             Write-Message -Message "No data returned from the API." -Level Warning
@@ -94,11 +94,9 @@ function Get-FabricDomain {
         # Step 7: Filter results based on provided parameters
         $domains = if ($DomainId) {
             $response.domains | Where-Object { $_.Id -eq $DomainId }
-        }
-        elseif ($DomainName) {
+        } elseif ($DomainName) {
             $response.domains | Where-Object { $_.DisplayName -eq $DomainName }
-        }
-        else {
+        } else {
             # Return all domains if no filter is provided
             Write-Message -Message "No filter provided. Returning all domains." -Level Debug
             return $response.domains
@@ -107,13 +105,11 @@ function Get-FabricDomain {
         # Step 8: Handle results
         if ($domains) {
             return $domains
-        }
-        else {
+        } else {
             Write-Message -Message "No domain found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve environment. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Get-FabricDomainWorkspace.ps1
+++ b/source/Public/Domain/Get-FabricDomainWorkspace.ps1
@@ -17,7 +17,7 @@ Fetches workspaces for the domain with ID "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -56,7 +56,7 @@ function Get-FabricDomainWorkspace {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-                    
+
         # Step 5: Handle empty response
         if (-not $response) {
             Write-Message -Message "No data returned from the API." -Level Warning
@@ -65,14 +65,12 @@ function Get-FabricDomainWorkspace {
         # Step 6: Handle results
         if ($response) {
             return $response.value
-        }
-        else {
+        } else {
             Write-Message -Message "No workspace found for the '$DomainId'." -Level Warning
             return $null
         }
 
-    }
-    catch {
+    } catch {
         # Step 7: Capture and log error details
         $errorDetails = Get-ErrorResponse($_.Exception)
         Write-Message -Message "Failed to retrieve domain workspaces. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/New-FabricDomain.ps1
+++ b/source/Public/Domain/New-FabricDomain.ps1
@@ -23,7 +23,7 @@ Creates a "Finance" domain under the parent domain with ID "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -82,7 +82,7 @@ function New-FabricDomain {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             201 {
@@ -94,24 +94,23 @@ function New-FabricDomain {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -119,8 +118,7 @@ function New-FabricDomain {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create domain. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Remove-FabricDomain.ps1
+++ b/source/Public/Domain/Remove-FabricDomain.ps1
@@ -17,7 +17,7 @@ Deletes the domain with ID "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -58,9 +58,8 @@ function Remove-FabricDomain {
         }
 
         Write-Message -Message "Domain '$DomainId' deleted successfully!" -Level Info
-       
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete domain '$DomainId'. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Unassign-FabricDomainWorkspace.ps1
+++ b/source/Public/Domain/Unassign-FabricDomainWorkspace.ps1
@@ -4,7 +4,7 @@
 Unassign workspaces from a specified Fabric domain.
 
 .DESCRIPTION
-The `Unassign -FabricDomainWorkspace` function allows you to Unassign  specific workspaces from a given Fabric domain or unassign all workspaces if no workspace IDs are specified. 
+The `Unassign -FabricDomainWorkspace` function allows you to Unassign  specific workspaces from a given Fabric domain or unassign all workspaces if no workspace IDs are specified.
 It makes a POST request to the relevant API endpoint for this operation.
 
 .PARAMETER DomainId
@@ -28,7 +28,7 @@ Unassigns the specified workspaces from the domain with ID "12345".
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 function Unassign-FabricDomainWorkspace {
@@ -37,7 +37,7 @@ function Unassign-FabricDomainWorkspace {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$DomainId,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [array]$WorkspaceIds
@@ -55,17 +55,16 @@ function Unassign-FabricDomainWorkspace {
 
         $apiEndpointUrl = "{0}/admin/domains/{1}/{2}" -f $FabricConfig.BaseUrl, $DomainId, $endpointSuffix
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
-        
+
 
         # Step 3: Construct the request body (if needed)
         $bodyJson = if ($WorkspaceIds) {
             $body = @{ workspacesIds = $WorkspaceIds }
             $body | ConvertTo-Json -Depth 2
-        }
-        else {
+        } else {
             $null
         }
-    
+
         Write-Message -Message "Request Body: $bodyJson" -Level Debug
         # Step 4: Make the API request to unassign specific workspaces
         $response = Invoke-RestMethod `
@@ -87,8 +86,7 @@ function Unassign-FabricDomainWorkspace {
             return $null
         }
         Write-Message -Message "Successfully unassigned workspaces to the domain with ID '$DomainId'." -Level Info
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to unassign workspaces to the domain with ID '$DomainId'. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Unassign-FabricDomainWorkspaceRoleAssignment.ps1
+++ b/source/Public/Domain/Unassign-FabricDomainWorkspaceRoleAssignment.ps1
@@ -27,7 +27,7 @@ Unassign the `Admins` role to the specified principals in the domain with ID "12
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -93,9 +93,8 @@ function Unassign-FabricDomainWorkspaceRoleAssignment {
             return $null
         }
         Write-Message -Message "Bulk role unassignment for domain '$DomainId' completed successfully!" -Level Info
-       
-    }
-    catch {
+
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to bulk assign roles in domain '$DomainId'. Error: $errorDetails" -Level Error

--- a/source/Public/Domain/Update-FabricDomain.ps1
+++ b/source/Public/Domain/Update-FabricDomain.ps1
@@ -3,7 +3,7 @@
 Updates a Fabric domain by its ID.
 
 .DESCRIPTION
-The `Update-FabricDomain` function modifies a specified domain in Microsoft Fabric using the provided parameters. 
+The `Update-FabricDomain` function modifies a specified domain in Microsoft Fabric using the provided parameters.
 
 .PARAMETER DomainId
 The unique identifier of the domain to be updated.
@@ -26,7 +26,7 @@ Updates the domain with ID "12345" with a new name, description, and contributor
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -98,15 +98,13 @@ function Update-FabricDomain {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-        
+
         # Step 6: Handle results
         Write-Message -Message "Domain '$DomainName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update domain '$DomainId'. Error: $errorDetails" -Level Error
     }
 }
- 

--- a/source/Public/Environment/Get-FabricEnvironment.ps1
+++ b/source/Public/Environment/Get-FabricEnvironment.ps1
@@ -1,5 +1,5 @@
 function Get-FabricEnvironment {
-<#
+    <#
 .SYNOPSIS
 Retrieves an environment or a list of environments from a specified workspace in Microsoft Fabric.
 
@@ -32,7 +32,7 @@ Retrieves all environments in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
 
     [CmdletBinding()]
     param (
@@ -115,13 +115,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -131,11 +129,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $environment = if ($EnvironmentId) {
             $environments | Where-Object { $_.Id -eq $EnvironmentId }
-        }
-        elseif ($EnvironmentName) {
+        } elseif ($EnvironmentName) {
             $environments | Where-Object { $_.DisplayName -eq $EnvironmentName }
-        }
-        else {
+        } else {
             # Return all workspaces if no filter is provided
             Write-Message -Message "No filter provided. Returning all environments." -Level Debug
             $environments
@@ -145,13 +141,11 @@ Author: Tiago Balabuch
         if ($environment) {
             Write-Message -Message "Environment found in the Workspace '$WorkspaceId'." -Level Debug
             return $environment
-        }
-        else {
+        } else {
             Write-Message -Message "No environment found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve environment. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Get-FabricEnvironmentLibrary.ps1
+++ b/source/Public/Environment/Get-FabricEnvironmentLibrary.ps1
@@ -3,8 +3,8 @@
 Retrieves the list of libraries associated with a specific environment in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-The Get-FabricEnvironmentLibrary function fetches library information for a given workspace and environment 
-using the Microsoft Fabric API. It ensures the authentication token is valid and validates the response 
+The Get-FabricEnvironmentLibrary function fetches library information for a given workspace and environment
+using the Microsoft Fabric API. It ensures the authentication token is valid and validates the response
 to handle errors gracefully.
 
 .PARAMETER WorkspaceId
@@ -22,7 +22,7 @@ Retrieves the libraries associated with the specified environment in the given w
 - Requires the `$FabricConfig` global object, including `BaseUrl` and `FabricHeaders`.
 - Uses `Test-TokenExpired` to validate the token before making API calls.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 function Get-FabricEnvironmentLibrary {
     [CmdletBinding()]
@@ -63,14 +63,13 @@ function Get-FabricEnvironmentLibrary {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-                    
+
         # Step 5: Handle results
         return $response
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve environment libraries. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Environment/Get-FabricEnvironmentSparkCompute.ps1
+++ b/source/Public/Environment/Get-FabricEnvironmentSparkCompute.ps1
@@ -3,8 +3,8 @@
 Retrieves the Spark compute details for a specific environment in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-The Get-FabricEnvironmentSparkCompute function communicates with the Microsoft Fabric API to fetch information 
-about Spark compute resources associated with a specified environment. It ensures that the API token is valid 
+The Get-FabricEnvironmentSparkCompute function communicates with the Microsoft Fabric API to fetch information
+about Spark compute resources associated with a specified environment. It ensures that the API token is valid
 and gracefully handles errors during the API call.
 
 .PARAMETER WorkspaceId
@@ -22,7 +22,7 @@ Retrieves Spark compute details for the specified environment in the given works
 - Requires the `$FabricConfig` global object, including `BaseUrl` and `FabricHeaders`.
 - Uses `Test-TokenExpired` to validate the token before making API calls.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 function Get-FabricEnvironmentSparkCompute {
     [CmdletBinding()]
@@ -63,14 +63,13 @@ function Get-FabricEnvironmentSparkCompute {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-                    
+
         # Step 5: Handle results
         return $response
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve environment Spark compute. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Environment/Get-FabricEnvironmentStagingLibrary.ps1
+++ b/source/Public/Environment/Get-FabricEnvironmentStagingLibrary.ps1
@@ -3,7 +3,7 @@
 Retrieves the staging library details for a specific environment in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-The Get-FabricEnvironmentStagingLibrary function interacts with the Microsoft Fabric API to fetch information 
+The Get-FabricEnvironmentStagingLibrary function interacts with the Microsoft Fabric API to fetch information
 about staging libraries associated with a specified environment. It ensures token validity and handles API errors gracefully.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@ Retrieves the staging libraries for the specified environment in the given works
 - Requires the `$FabricConfig` global object, including `BaseUrl` and `FabricHeaders`.
 - Uses `Test-TokenExpired` to validate the token before making API calls.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 function Get-FabricEnvironmentStagingLibrary {
     [CmdletBinding()]
@@ -55,7 +55,7 @@ function Get-FabricEnvironmentStagingLibrary {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
+
         # Step 4: Validate the response code
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -63,14 +63,13 @@ function Get-FabricEnvironmentStagingLibrary {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-                    
+
         # Step 5: Handle results
         return $response.customLibraries
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve environment spark compute. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Environment/Get-FabricEnvironmentStagingSparkCompute.ps1
+++ b/source/Public/Environment/Get-FabricEnvironmentStagingSparkCompute.ps1
@@ -1,5 +1,5 @@
 function Get-FabricEnvironmentStagingSparkCompute {
-<#
+    <#
 .SYNOPSIS
 Retrieves staging Spark compute details for a specific environment in a Microsoft Fabric workspace.
 
@@ -23,7 +23,7 @@ Retrieves the staging Spark compute configurations for the specified environment
 - Uses `Test-TokenExpired` to validate the token before making API calls.
 
 Author: Tiago Balabuch
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -66,8 +66,7 @@ Author: Tiago Balabuch
 
         # Step 5: Handle results
         return $response
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve environment spark compute. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/New-FabricEnvironment.ps1
+++ b/source/Public/Environment/New-FabricEnvironment.ps1
@@ -23,7 +23,7 @@ Creates an environment named "DevEnv" in workspace "12345" with the specified de
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -89,24 +89,23 @@ function New-FabricEnvironment {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -114,8 +113,7 @@ function New-FabricEnvironment {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create environment. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Publish-FabricEnvironment.ps1
+++ b/source/Public/Environment/Publish-FabricEnvironment.ps1
@@ -3,7 +3,7 @@
 Publishes a staging environment in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function interacts with the Microsoft Fabric API to initiate the publishing process for a staging environment. 
+This function interacts with the Microsoft Fabric API to initiate the publishing process for a staging environment.
 It validates the authentication token, constructs the API request, and handles both immediate and long-running operations.
 
 
@@ -22,7 +22,7 @@ Initiates the publishing process for the specified staging environment.
 - Requires the `$FabricConfig` global object, including `BaseUrl` and `FabricHeaders`.
 - Uses `Test-TokenExpired` to validate the token before making API calls.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 
 function Publish-FabricEnvironment {
@@ -70,24 +70,23 @@ function Publish-FabricEnvironment {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -95,8 +94,7 @@ function Publish-FabricEnvironment {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create environment. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Remove-FabricEnvironment.ps1
+++ b/source/Public/Environment/Remove-FabricEnvironment.ps1
@@ -20,7 +20,7 @@ Deletes the environment with ID "67890" from workspace "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Validates token expiration before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -64,9 +64,8 @@ function Remove-FabricEnvironment {
             return $null
         }
         Write-Message -Message "Environment '$EnvironmentId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete environment '$EnvironmentId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Remove-FabricEnvironmentStagingLibrary.ps1
+++ b/source/Public/Environment/Remove-FabricEnvironmentStagingLibrary.ps1
@@ -1,5 +1,5 @@
 function Remove-FabricEnvironmentStagingLibrary {
-<#
+    <#
 .SYNOPSIS
 Deletes a specified library from the staging environment in a Microsoft Fabric workspace.
 
@@ -27,7 +27,7 @@ Deletes the specified library from the staging environment in the specified work
 - This function currently supports deleting one library at a time.
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -65,7 +65,7 @@ Author: Tiago Balabuch
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
 
-            # Step 4: Validate the response code
+        # Step 4: Validate the response code
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
             Write-Message -Message "Error: $($response.message)" -Level Error
@@ -73,8 +73,7 @@ Author: Tiago Balabuch
             return $null
         }
         Write-Message -Message "Staging library $LibraryName for the Environment '$EnvironmentId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-    }
-    catch {
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete environment '$EnvironmentId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Stop-FabricEnvironmentPublish.ps1
+++ b/source/Public/Environment/Stop-FabricEnvironmentPublish.ps1
@@ -21,10 +21,10 @@ Cancels the publish operation for the specified environment.
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Validates token expiration before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
-function Stop-FabricEnvironmentPublish{
+function Stop-FabricEnvironmentPublish {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -66,9 +66,8 @@ function Stop-FabricEnvironmentPublish{
             return $null
         }
         Write-Message -Message "Publication for environment '$EnvironmentId' has been successfully canceled." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to cancel publication for environment '$EnvironmentId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Update-FabricEnvironment.ps1
+++ b/source/Public/Environment/Update-FabricEnvironment.ps1
@@ -102,8 +102,7 @@ function Update-FabricEnvironment {
         # Step 6: Handle results
         Write-Message -Message "Environment '$EnvironmentName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Environment. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Update-FabricEnvironmentStagingSparkCompute.ps1
+++ b/source/Public/Environment/Update-FabricEnvironmentStagingSparkCompute.ps1
@@ -52,7 +52,7 @@ Update-FabricEnvironmentStagingSparkCompute -WorkspaceId "workspace-12345" -Envi
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 function Update-FabricEnvironmentStagingSparkCompute {
@@ -61,7 +61,7 @@ function Update-FabricEnvironmentStagingSparkCompute {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$WorkspaceId,
-        
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$EnvironmentId,
@@ -156,8 +156,8 @@ function Update-FabricEnvironmentStagingSparkCompute {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
-            # Step 5: Validate the response code
+
+        # Step 5: Validate the response code
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
             Write-Message -Message "Error: $($response.message)" -Level Error
@@ -168,8 +168,7 @@ function Update-FabricEnvironmentStagingSparkCompute {
         # Step 6: Handle results
         Write-Message -Message "Environment staging Spark compute updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update environment staging Spark compute. Error: $errorDetails" -Level Error

--- a/source/Public/Environment/Upload-FabricEnvironmentStagingLibrary.ps1
+++ b/source/Public/Environment/Upload-FabricEnvironmentStagingLibrary.ps1
@@ -20,7 +20,7 @@ Upload-FabricEnvironmentStagingLibrary -WorkspaceId "workspace-12345" -Environme
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 function Upload-FabricEnvironmentStagingLibrary {
@@ -29,7 +29,7 @@ function Upload-FabricEnvironmentStagingLibrary {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$WorkspaceId,
-        
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$EnvironmentId
@@ -46,9 +46,9 @@ function Upload-FabricEnvironmentStagingLibrary {
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 3: Construct the request body
-        
+
         # Step 4: Make the API request
-       $response = Invoke-RestMethod `
+        $response = Invoke-RestMethod `
             -Headers $FabricConfig.FabricHeaders `
             -Uri $apiEndpointUrl `
             -Method Post `
@@ -70,8 +70,7 @@ function Upload-FabricEnvironmentStagingLibrary {
         # Step 6: Handle results
         Write-Message -Message "Environment staging library uploaded successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to upload environment staging library. Error: $errorDetails" -Level Error

--- a/source/Public/Eventhouse/Get-FabricEventhouse.ps1
+++ b/source/Public/Eventhouse/Get-FabricEventhouse.ps1
@@ -1,5 +1,5 @@
 function Get-FabricEventhouse {
-<#
+    <#
     .SYNOPSIS
         Retrieves Fabric Eventhouses
 
@@ -60,7 +60,7 @@ function Get-FabricEventhouse {
         - 2024-11-09 - FGE: Added DisplaName as Alias for EventhouseName
         - 2024-11-16 - FGE: Added Verbose Output
         - 2024-11-27 - FGE: Added more Verbose Output
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -141,13 +141,11 @@ function Get-FabricEventhouse {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -157,11 +155,9 @@ function Get-FabricEventhouse {
         # Step 8: Filter results based on provided parameters
         $eventhouse = if ($EventhouseId) {
             $eventhouses | Where-Object { $_.Id -eq $EventhouseId }
-        }
-        elseif ($EventhouseName) {
+        } elseif ($EventhouseName) {
             $eventhouses | Where-Object { $_.DisplayName -eq $EventhouseName }
-        }
-        else {
+        } else {
             # Return all eventhouses if no filter is provided
             Write-Message -Message "No filter provided. Returning all Eventhouses." -Level Debug
             $eventhouses
@@ -171,13 +167,11 @@ function Get-FabricEventhouse {
         if ($eventhouse) {
             Write-Message -Message "Eventhouse found in the Workspace '$WorkspaceId'." -Level Debug
             return $eventhouse
-        }
-        else {
+        } else {
             Write-Message -Message "No Eventhouse found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Eventhouse. Error: $errorDetails" -Level Error

--- a/source/Public/Eventhouse/Get-FabricEventhouseDefinition.ps1
+++ b/source/Public/Eventhouse/Get-FabricEventhouseDefinition.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricEventhouseDefinition {
     [CmdletBinding()]
@@ -53,11 +53,11 @@ function Get-FabricEventhouseDefinition {
 
         # Step 3: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/eventhouses/{2}/getDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $EventhouseId
-        
+
         if ($EventhouseFormat) {
             $apiEndpointUrl = "{0}?format={1}" -f $apiEndpointUrl, $EventhouseFormat
         }
-        
+
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 4: Make the API request
@@ -81,30 +81,29 @@ function Get-FabricEventhouseDefinition {
 
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
-                    $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId 
+
+                    $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -114,11 +113,10 @@ function Get-FabricEventhouseDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Eventhouse. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Eventhouse/New-FabricEventhouse.ps1
+++ b/source/Public/Eventhouse/New-FabricEventhouse.ps1
@@ -1,5 +1,5 @@
 function New-FabricEventhouse {
-<#
+    <#
     .SYNOPSIS
         Creates a new Eventhouse in a specified Microsoft Fabric workspace.
 
@@ -32,7 +32,7 @@ function New-FabricEventhouse {
 
         Author: Tiago Balabuch
 
-#>
+    #>
 
     [CmdletBinding()]
     param (
@@ -82,7 +82,7 @@ function New-FabricEventhouse {
                 # Initialize definition if it doesn't exist
                 if (-not $body.definition) {
                     $body.definition = @{
-                        parts  = @()
+                        parts = @()
                     }
                 }
 
@@ -92,8 +92,7 @@ function New-FabricEventhouse {
                     payload     = $eventhouseEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in Eventhouse definition." -Level Error
                 return $null
             }
@@ -106,7 +105,7 @@ function New-FabricEventhouse {
                 # Initialize definition if it doesn't exist
                 if (-not $body.definition) {
                     $body.definition = @{
-                        parts  = @()
+                        parts = @()
                     }
                 }
 
@@ -116,8 +115,7 @@ function New-FabricEventhouse {
                     payload     = $eventhouseEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -170,8 +168,7 @@ function New-FabricEventhouse {
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
 
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -185,8 +182,7 @@ function New-FabricEventhouse {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create Eventhouse. Error: $errorDetails" -Level Error

--- a/source/Public/Eventhouse/Remove-FabricEventhouse.ps1
+++ b/source/Public/Eventhouse/Remove-FabricEventhouse.ps1
@@ -1,5 +1,5 @@
 function Remove-FabricEventhouse {
-<#
+    <#
 .SYNOPSIS
     Removes an Eventhouse from a specified Microsoft Fabric workspace.
 
@@ -35,7 +35,7 @@ function Remove-FabricEventhouse {
 
     Author: Tiago Balabuch
 
-#>
+    #>
 
     [CmdletBinding()]
     param (
@@ -67,7 +67,7 @@ function Remove-FabricEventhouse {
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
 
-            # Step 4: Handle response
+        # Step 4: Handle response
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
             Write-Message -Message "Error: $($response.message)" -Level Error
@@ -77,8 +77,7 @@ function Remove-FabricEventhouse {
         }
 
         Write-Message -Message "Eventhouse '$EventhouseId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-    }
-    catch {
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete Eventhouse '$EventhouseId'. Error: $errorDetails" -Level Error

--- a/source/Public/Eventhouse/Update-FabricEventhouse.ps1
+++ b/source/Public/Eventhouse/Update-FabricEventhouse.ps1
@@ -3,7 +3,7 @@
     Updates an existing Eventhouse in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing Eventhouse 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing Eventhouse
     in the specified workspace. It supports optional parameters for Eventhouse description.
 
 .PARAMETER WorkspaceId
@@ -27,15 +27,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricEventhouse {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$EventhouseId,
@@ -96,8 +96,7 @@ function Update-FabricEventhouse {
         # Step 6: Handle results
         Write-Message -Message "Eventhouse '$EventhouseName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Eventhouse. Error: $errorDetails" -Level Error

--- a/source/Public/Eventstream/Get-FabricEventstream.ps1
+++ b/source/Public/Eventstream/Get-FabricEventstream.ps1
@@ -1,5 +1,5 @@
 function Get-FabricEventstream {
-<#
+    <#
 .SYNOPSIS
 Retrieves an Eventstream or a list of Eventstreams from a specified workspace in Microsoft Fabric.
 
@@ -33,7 +33,7 @@ Retrieves all Eventstreams in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
 
 
     [CmdletBinding()]
@@ -119,13 +119,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -136,11 +134,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $eventstream = if ($EventstreamId) {
             $eventstreams | Where-Object { $_.Id -eq $EventstreamId }
-        }
-        elseif ($EventstreamName) {
+        } elseif ($EventstreamName) {
             $eventstreams | Where-Object { $_.DisplayName -eq $EventstreamName }
-        }
-        else {
+        } else {
             # Return all eventstreams if no filter is provided
             Write-Message -Message "No filter provided. Returning all Eventstreams." -Level Debug
             $eventstreams
@@ -150,13 +146,11 @@ Author: Tiago Balabuch
         if ($eventstream) {
             Write-Message -Message "Eventstream found matching the specified criteria." -Level Debug
             return $eventstream
-        }
-        else {
+        } else {
             Write-Message -Message "No Eventstream found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Eventstream. Error: $errorDetails" -Level Error

--- a/source/Public/Eventstream/Get-FabricEventstreamDefinition.ps1
+++ b/source/Public/Eventstream/Get-FabricEventstreamDefinition.ps1
@@ -4,7 +4,7 @@
 Retrieves the definition of a Eventstream from a specific workspace in Microsoft Fabric.
 
 .DESCRIPTION
-This function fetches the Eventstream's content or metadata from a workspace. 
+This function fetches the Eventstream's content or metadata from a workspace.
 Handles both synchronous and asynchronous operations, with detailed logging and error handling.
 
 .PARAMETER WorkspaceId
@@ -85,37 +85,35 @@ function Get-FabricEventstreamDefinition {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
-        
+
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Eventstream. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Eventstream/New-FabricEventstream.ps1
+++ b/source/Public/Eventstream/New-FabricEventstream.ps1
@@ -1,5 +1,5 @@
 function New-FabricEventstream {
-<#
+    <#
 .SYNOPSIS
 Creates a new Eventstream in a specified Microsoft Fabric workspace.
 
@@ -34,7 +34,7 @@ An optional path to the platform-specific definition (e.g., .platform file) to u
 Author: Tiago Balabuch
 
 #>
-#TODO SupportsShouldProcess
+    #TODO SupportsShouldProcess
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -96,8 +96,7 @@ Author: Tiago Balabuch
                     payload     = $EventstreamEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in Eventstream definition." -Level Error
                 return $null
             }
@@ -121,8 +120,7 @@ Author: Tiago Balabuch
                     payload     = $EventstreamEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -167,8 +165,7 @@ Author: Tiago Balabuch
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
 
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -180,8 +177,7 @@ Author: Tiago Balabuch
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create Eventstream. Error: $errorDetails" -Level Error

--- a/source/Public/Eventstream/Remove-FabricEventstream.ps1
+++ b/source/Public/Eventstream/Remove-FabricEventstream.ps1
@@ -1,5 +1,5 @@
 function Remove-FabricEventstream {
-<#
+    <#
 .SYNOPSIS
 Deletes an Eventstream from a specified workspace in Microsoft Fabric.
 
@@ -28,9 +28,9 @@ Deletes the Eventstream with ID "67890" from workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
 
-#TODO SupportsShouldProcess
+    #TODO SupportsShouldProcess
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -40,7 +40,7 @@ Author: Tiago Balabuch
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$EventstreamId
-#TODO Add EventstreamName parameter to validate the name of the Eventstream to delete.
+        #TODO Add EventstreamName parameter to validate the name of the Eventstream to delete.
     )
 
     try {
@@ -71,8 +71,7 @@ Author: Tiago Balabuch
         }
         Write-Message -Message "Eventstream '$EventstreamId' deleted successfully from workspace '$WorkspaceId'." -Level Info
 
-    }
-    catch {
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete Eventstream '$EventstreamId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Eventstream/Update-FabricEventstream.ps1
+++ b/source/Public/Eventstream/Update-FabricEventstream.ps1
@@ -101,8 +101,7 @@ function Update-FabricEventstream {
         # Step 6: Handle results
         Write-Message -Message "Eventstream '$EventstreamName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Eventstream. Error: $errorDetails" -Level Error

--- a/source/Public/External Data Share/Get-FabricExternalDataShares.ps1
+++ b/source/Public/External Data Share/Get-FabricExternalDataShares.ps1
@@ -7,7 +7,7 @@
     It handles token validation, constructs the API URL, makes the API request, and processes the response.
 
 .EXAMPLE
-     Get-FabricExternalDataShares 
+     Get-FabricExternalDataShares
     This example retrieves the External Data Shares details
 
 .NOTES
@@ -21,30 +21,29 @@ function Get-FabricExternalDataShares {
     param ( )
 
     try {
-        
-         # Validate authentication token before proceeding
+
+        # Validate authentication token before proceeding
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
 
-       # Construct the API endpoint URI for retrieving external data shares
+        # Construct the API endpoint URI for retrieving external data shares
         Write-Message -Message "Constructing API endpoint URI..." -Level Debug
         $apiEndpointURI = "{0}/admin/items/externalDataShares" -f $FabricConfig.BaseUrl, $WorkspaceId
-        
+
         # Invoke the API request to retrieve external data shares
         $externalDataShares = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
-            -Method Get 
+            -Method Get
 
         # Return the retrieved external data shares
         Write-Message -Message "Successfully retrieved external data shares." -Level Debug
         return $externalDataShares
-    }
-    catch {
+    } catch {
         # Capture and log detailed error information if the API request fails
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve External Data Shares. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/External Data Share/Revoke-FabricExternalDataShares.ps1
+++ b/source/Public/External Data Share/Revoke-FabricExternalDataShares.ps1
@@ -1,5 +1,5 @@
 function Revoke-FabricExternalDataShares {
-<#
+    <#
 .SYNOPSIS
     Retrieves External Data Shares details from a specified Microsoft Fabric.
 
@@ -25,7 +25,7 @@ function Revoke-FabricExternalDataShares {
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-#>
+    #>
 
     [CmdletBinding()]
     param (
@@ -40,7 +40,7 @@ function Revoke-FabricExternalDataShares {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$ExternalDataShareId
-     )
+    )
 
     try {
 
@@ -61,8 +61,7 @@ function Revoke-FabricExternalDataShares {
         # Step 4: Return retrieved data
         Write-Message -Message "Successfully revoked external data shares." -Level Info
         return $externalDataShares
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve External Data Shares. Error: $errorDetails" -Level Error

--- a/source/Public/Get-AllFabricDatasetRefreshes.ps1
+++ b/source/Public/Get-AllFabricDatasetRefreshes.ps1
@@ -1,5 +1,5 @@
 function Get-FabricDatasetRefreshes {
-<#
+    <#
 .SYNOPSIS
 Retrieves all refreshes for all datasets in all PowerBI workspaces.
 
@@ -13,9 +13,9 @@ This example retrieves all refreshes for all datasets in all PowerBI workspaces.
 
 .NOTES
 The function makes a GET request to the PowerBI API to retrieve the refreshes. It loops through each workspace and each dataset in each workspace. If a dataset is refreshable, it retrieves the refreshes for the dataset and selects the most recent one. It then creates a PSCustomObject with information about the refresh and adds it to an array of refreshes. Finally, it returns the array of refreshes.
-#>
+    #>
 
-# This function retrieves all refreshes for all datasets in all PowerBI workspaces.
+    # This function retrieves all refreshes for all datasets in all PowerBI workspaces.
     # Define aliases for the function for flexibility.
 
     Confirm-FabricAuthToken | Out-Null

--- a/source/Public/Get-FabricAPIClusterURI.ps1
+++ b/source/Public/Get-FabricAPIClusterURI.ps1
@@ -1,5 +1,5 @@
-function Get-FabricAPIclusterURI  {
-<#
+function Get-FabricAPIclusterURI {
+    <#
 .SYNOPSIS
     Retrieves the cluster URI for the tenant.
 
@@ -14,9 +14,9 @@ function Get-FabricAPIclusterURI  {
 .NOTES
     The function retrieves the PowerBI access token and makes a GET request to the PowerBI API to retrieve the datasets. It then extracts the '@odata.context' property from the response, splits it on the '/' character, and selects the third element. This element is used to construct the cluster URI, which is then returned by the function.
 
-#>
+    #>
 
-#This function retrieves the cluster URI for the tenant.
+    #This function retrieves the cluster URI for the tenant.
     # Define aliases for the function for flexibility.
     [Alias("Get-FabAPIClusterURI")]
     Param (

--- a/source/Public/Get-FabricAuthToken.ps1
+++ b/source/Public/Get-FabricAuthToken.ps1
@@ -22,18 +22,18 @@
 #>
 
 function Get-FabricAuthToken {
-   [Alias("Get-FabAuthToken")]
-   [CmdletBinding()]
-   param
-   (
-   )
+    [Alias("Get-FabAuthToken")]
+    [CmdletBinding()]
+    param
+    (
+    )
 
-   # Check if the Fabric token is already set
-   if (!$FabricSession.FabricToken) {
-      # If not, set the Fabric token
-      Set-FabricAuthToken
-   }
+    # Check if the Fabric token is already set
+    if (!$FabricSession.FabricToken) {
+        # If not, set the Fabric token
+        Set-FabricAuthToken
+    }
 
-   # Output the Fabric token
-   return $FabricSession.FabricToken
+    # Output the Fabric token
+    return $FabricSession.FabricToken
 }

--- a/source/Public/Get-FabricConnection.ps1
+++ b/source/Public/Get-FabricConnection.ps1
@@ -1,5 +1,5 @@
 function Get-FabricConnection {
-<#
+    <#
 .SYNOPSIS
 Retrieves Fabric connections.
 
@@ -22,26 +22,25 @@ This example retrieves specific connection from Fabric with ID "12345".
 .NOTES
 https://learn.microsoft.com/en-us/rest/api/fabric/core/connections/get-connection?tabs=HTTP
 https://learn.microsoft.com/en-us/rest/api/fabric/core/connections/list-connections?tabs=HTTP
-#>
-  [CmdletBinding()]
-  param
-  (
-    [Parameter(Mandatory = $false)]
-    [string]$connectionId
-  )
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $false)]
+        [string]$connectionId
+    )
 
-  begin {
-    Confirm-FabricAuthToken | Out-Null
-  }
-
-  process {
-    if ($connectionId) {
-      $result = Invoke-FabricAPIRequest -Uri "/connections/$($connectionId)" -Method GET
-    }
-    else {
-      $result = Invoke-FabricAPIRequest -Uri "/connections" -Method GET
+    begin {
+        Confirm-FabricAuthToken | Out-Null
     }
 
-    return $result.value
-  }
+    process {
+        if ($connectionId) {
+            $result = Invoke-FabricAPIRequest -Uri "/connections/$($connectionId)" -Method GET
+        } else {
+            $result = Invoke-FabricAPIRequest -Uri "/connections" -Method GET
+        }
+
+        return $result.value
+    }
 }

--- a/source/Public/Get-FabricDatasetRefreshes.ps1
+++ b/source/Public/Get-FabricDatasetRefreshes.ps1
@@ -31,14 +31,14 @@ function Get-FabricDatasetRefreshes {
 
     # Define a mandatory parameter for the dataset ID.
     Param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$DatasetID,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$workspaceId
     )
 
     # Get the dataset information.
-    $di = get-powerbidataset -id $DatasetID -WorkspaceId $workspaceId
+    $di = Get-PowerBIDataset -id $DatasetID -WorkspaceId $workspaceId
 
     # Check if the dataset is refreshable.
     if ($di.isrefreshable -eq "True") {

--- a/source/Public/Get-FabricDebugInfo.ps1
+++ b/source/Public/Get-FabricDebugInfo.ps1
@@ -1,7 +1,7 @@
 function Get-FabricDebugInfo {
     #Requires -Version 7.1
 
-<#
+    <#
 .SYNOPSIS
     Shows internal debug information about the current session.
 
@@ -21,26 +21,26 @@ function Get-FabricDebugInfo {
 
     - 2024-12-22 - FGE: Added Verbose Output
 
-#>
+    #>
 
-[CmdletBinding()]
+    [CmdletBinding()]
     param (
 
     )
 
-begin {}
+    begin { }
 
-process {
-    Write-Verbose "Show current session object"
+    process {
+        Write-Verbose "Show current session object"
 
-    return @{
-        FabricSession = $script:FabricSession
-        AzureSession  = $script:AzureSession
-        FabricConfig  = $script:FabricConfig
+        return @{
+            FabricSession = $script:FabricSession
+            AzureSession  = $script:AzureSession
+            FabricConfig  = $script:FabricConfig
+        }
+
     }
 
-}
-
-end {}
+    end { }
 
 }

--- a/source/Public/Get-FabricUsageMetricsQuery.ps1
+++ b/source/Public/Get-FabricUsageMetricsQuery.ps1
@@ -1,5 +1,5 @@
 function Get-FabricUsageMetricsQuery {
-<#
+    <#
 .SYNOPSIS
 Retrieves usage metrics for a specific dataset.
 
@@ -31,30 +31,30 @@ This example retrieves the usage metrics for a specific dataset given the datase
 
 .NOTES
 The function defines the headers and body for a POST request to the PowerBI API to retrieve the usage metrics for the specified dataset. It then makes the POST request and returns the response.
-#>
+    #>
 
-# This function retrieves usage metrics for a specific dataset.
-  # Define aliases for the function for flexibility.
-  [Alias("Get-FabUsageMetricsQuery")]
+    # This function retrieves usage metrics for a specific dataset.
+    # Define aliases for the function for flexibility.
+    [Alias("Get-FabUsageMetricsQuery")]
 
-  # Define parameters for the dataset ID, group ID, report name, token, and impersonated user.
-  param (
-    [Parameter(Mandatory = $true)]
-    [string]$DatasetID,
-    [Parameter(Mandatory = $true)]
-    [string]$groupId,
-    [Parameter(Mandatory = $true)]
-    $reportname,
-    [Parameter(Mandatory = $false)]
-    [string]$ImpersonatedUser = ""
-  )
+    # Define parameters for the dataset ID, group ID, report name, token, and impersonated user.
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$DatasetID,
+        [Parameter(Mandatory = $true)]
+        [string]$groupId,
+        [Parameter(Mandatory = $true)]
+        $reportname,
+        [Parameter(Mandatory = $false)]
+        [string]$ImpersonatedUser = ""
+    )
 
-  # Confirm the authentication token.
-  Confirm-FabricAuthToken | Out-Null
+    # Confirm the authentication token.
+    Confirm-FabricAuthToken | Out-Null
 
-  # Define the body of the POST request.
-  if ($ImpersonatedUser -ne "") {
-    $reportbody = '{
+    # Define the body of the POST request.
+    if ($ImpersonatedUser -ne "") {
+        $reportbody = '{
       "queries": [
         {
           "query": "EVALUATE VALUES(' + $reportname + ')"
@@ -63,11 +63,10 @@ The function defines the headers and body for a POST request to the PowerBI API 
       "serializerSettings": {
         "includeNulls": true
       },
-      "impersonatedUserName": "'+ $ImpersonatedUser + '"
+      "impersonatedUserName": "' + $ImpersonatedUser + '"
     }'
-  }
-  else {
-    $reportbody = '{
+    } else {
+        $reportbody = '{
       "queries": [
         {
           "query": "EVALUATE VALUES(' + $reportname + ')"
@@ -77,8 +76,8 @@ The function defines the headers and body for a POST request to the PowerBI API 
         "includeNulls": true
       }
     }'
-  }
-  # Make a POST request to the PowerBI API to retrieve the usage metrics for the specified dataset.
-  # The function returns the response of the POST request.
-  return Invoke-RestMethod -uri "$($PowerBI.BaseApiUrl)/groups/$groupId/datasets/$DatasetID/executeQueries" -Headers $FabricSession.HeaderParams -Body $reportbody -Method Post
+    }
+    # Make a POST request to the PowerBI API to retrieve the usage metrics for the specified dataset.
+    # The function returns the response of the POST request.
+    return Invoke-RestMethod -uri "$($PowerBI.BaseApiUrl)/groups/$groupId/datasets/$DatasetID/executeQueries" -Headers $FabricSession.HeaderParams -Body $reportbody -Method Post
 }

--- a/source/Public/Get-SHA256.ps1
+++ b/source/Public/Get-SHA256.ps1
@@ -1,6 +1,6 @@
 
 function Get-Sha256 ($string) {
-<#
+    <#
 .SYNOPSIS
 Calculates the SHA256 hash of a string.
 
@@ -17,9 +17,9 @@ This example calculates the SHA256 hash of a string.
 
 .NOTES
 The function creates a new SHA256CryptoServiceProvider object, converts the string to a byte array using UTF8 encoding, computes the SHA256 hash of the byte array, converts the hash to a string and removes any hyphens, and returns the resulting hash.
-#>
+    #>
 
-# This function calculates the SHA256 hash of a string.
+    # This function calculates the SHA256 hash of a string.
     # Create a new SHA256CryptoServiceProvider object.
     $sha256 = New-Object System.Security.Cryptography.SHA256CryptoServiceProvider
 

--- a/source/Public/Invoke-FabricDatasetRefresh.ps1
+++ b/source/Public/Invoke-FabricDatasetRefresh.ps1
@@ -33,8 +33,7 @@ function Invoke-FabricDatasetRefresh {
     if ((Get-FabricDataset -DatasetId $DatasetID).isrefreshable -eq $false) {
         # If the dataset is not refreshable, write an error
         Write-Error "Dataset is not refreshable"
-    }
-    else {
+    } else {
         # If the dataset is refreshable, invoke a PowerBI REST method to refresh the dataset
         # The URL for the request is constructed using the provided workspace ID and dataset ID.
 

--- a/source/Public/Item/Export-FabricItem.ps1
+++ b/source/Public/Item/Export-FabricItem.ps1
@@ -51,7 +51,7 @@ Function Export-FabricItem {
 
         $parts = $item.definition.parts
 
-        if (!(test-path $path)) {
+        if (!(Test-Path $path)) {
             New-Item -ItemType Directory -Force -Path $path
         }
 
@@ -63,14 +63,13 @@ Function Export-FabricItem {
         }
 
         # Display a message indicating the items were exported
-        write-output "Items exported to $path"
+        Write-Output "Items exported to $path"
     } else {
         $items = Invoke-FabricAPIRequest -Uri "workspaces/$workspaceId/items" -Method Get
 
         if ($filter) {
             $items = $items.value | Where-Object $filter
-        }
-        else {
+        } else {
             $items = $items.value
         }
 
@@ -83,22 +82,22 @@ Function Export-FabricItem {
             $itemOutputPath = "$path\$workspaceId\$($itemName).$($itemType)"
 
             if ($itemType -in @("report", "semanticmodel", "notebook", "SparkJobDefinitionV1", "DataPipeline")) {
-                write-output "Getting definition of: $itemId / $itemName / $itemType"
+                Write-Output "Getting definition of: $itemId / $itemName / $itemType"
 
                 $response = Invoke-FabricAPIRequest -Uri "workspaces/$workspaceId/items/$itemId/getDefinition" -Method Post
 
                 $partCount = $response.definition.parts.Count
 
-                write-output "Parts: $partCount"
+                Write-Output "Parts: $partCount"
                 if ($partCount -gt 0) {
                     foreach ($part in $response.definition.parts) {
-                        write-output "Saving part: $($part.path)"
+                        Write-Output "Saving part: $($part.path)"
                         $outputFilePath = "$itemOutputPath\$($part.path.Replace("/", "\"))"
 
                         New-Item -ItemType Directory -Path (Split-Path $outputFilePath -Parent) -ErrorAction SilentlyContinue | Out-Null
                         $payload = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($part.payload))
                         $payload | Out-File -FilePath "$outputFilePath"
-             
+
                     }
 
                     @{
@@ -107,9 +106,8 @@ Function Export-FabricItem {
 
                     } | ConvertTo-Json | Out-File "$itemOutputPath\item.metadata.json"
                 }
-            }
-            else {
-                write-output "Type '$itemType' not available for export."
+            } else {
+                Write-Output "Type '$itemType' not available for export."
             }
         }
     }

--- a/source/Public/Item/Get-FabricItem.ps1
+++ b/source/Public/Item/Get-FabricItem.ps1
@@ -1,5 +1,5 @@
 function Get-FabricItem {
-<#
+    <#
 .SYNOPSIS
 Retrieves fabric items from a workspace.
 
@@ -27,45 +27,43 @@ This example retrieves all fabric items of type "file" from the workspace with I
 This function was originally written by Rui Romano.
 https://github.com/RuiRomano/fabricps-pbip
 
-#>
-  [CmdletBinding()]
-  param
-  (
-    [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceId')]
-    [string]$workspaceId,
+    #>
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceId')]
+        [string]$workspaceId,
 
-    [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceObject', ValueFromPipeline = $true )]
-    $Workspace,
+        [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceObject', ValueFromPipeline = $true )]
+        $Workspace,
 
-    [Parameter(Mandatory = $false)]
-    [Alias("itemType")]
-    [string]$type,
+        [Parameter(Mandatory = $false)]
+        [Alias("itemType")]
+        [string]$type,
 
-    [Parameter(Mandatory = $false)]
-    [string]$itemID
-  )
+        [Parameter(Mandatory = $false)]
+        [string]$itemID
+    )
 
-  begin {
-    Confirm-FabricAuthToken | Out-Null
-  }
-
-  process {
-    if ($PSCmdlet.ParameterSetName -eq 'WorkspaceObject') {
-      $workspaceID = $Workspace.id
+    begin {
+        Confirm-FabricAuthToken | Out-Null
     }
-    if ($itemID) {
-      $result = Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items/$($itemID)" -Method Get
+
+    process {
+        if ($PSCmdlet.ParameterSetName -eq 'WorkspaceObject') {
+            $workspaceID = $Workspace.id
+        }
+        if ($itemID) {
+            $result = Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items/$($itemID)" -Method Get
+        } else {
+            if ($type) {
+                $result = Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items?type=$type" -Method Get
+            } else {
+                # Invoke the Fabric API to get the workspaces
+                $result = Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items" -Method Get
+            }
+            # Output the result
+            return $result.value
+        }
     }
-    else {
-      if ($type) {
-        $result = Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items?type=$type" -Method Get
-      }
-      else {
-        # Invoke the Fabric API to get the workspaces
-        $result = Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items" -Method Get
-      }
-      # Output the result
-      return $result.value
-    }
-  }
 }

--- a/source/Public/Item/Remove-FabricItem.ps1
+++ b/source/Public/Item/Remove-FabricItem.ps1
@@ -31,40 +31,40 @@
 #>
 
 Function Remove-FabricItem {
-   [CmdletBinding(SupportsShouldProcess)]
-   param
-   (
-      [Parameter(Mandatory = $true)]
-      [string]$workspaceId,
-      [Parameter(Mandatory = $false)]
-      [string]$filter,
-      [Parameter(Mandatory = $false)]
-      [string]$itemID
-   )
+    [CmdletBinding(SupportsShouldProcess)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$workspaceId,
+        [Parameter(Mandatory = $false)]
+        [string]$filter,
+        [Parameter(Mandatory = $false)]
+        [string]$itemID
+    )
 
-   Confirm-FabricAuthToken | Out-Null
+    Confirm-FabricAuthToken | Out-Null
 
-   # Invoke the Fabric API to get the items in the workspace
-   if ($PSCmdlet.ShouldProcess("Remove items from workspace $workspaceId")) {
-      if ($itemID) {
-         Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items/$($itemID)" -Method Delete
-      } else {
-         $items = Invoke-FabricAPIRequest -Uri "workspaces/$workspaceId/items" -Method Get
+    # Invoke the Fabric API to get the items in the workspace
+    if ($PSCmdlet.ShouldProcess("Remove items from workspace $workspaceId")) {
+        if ($itemID) {
+            Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/items/$($itemID)" -Method Delete
+        } else {
+            $items = Invoke-FabricAPIRequest -Uri "workspaces/$workspaceId/items" -Method Get
 
-         # Display the count of existing items
-         Write-Output "Existing items: $($items.Count)"
+            # Display the count of existing items
+            Write-Output "Existing items: $($items.Count)"
 
-         # If a filter is provided
-         if ($filter) {
-            # Filter the items whose DisplayName matches the filter
-            $items = $items | Where-Object { $_.DisplayName -like $filter }
-         }
+            # If a filter is provided
+            if ($filter) {
+                # Filter the items whose DisplayName matches the filter
+                $items = $items | Where-Object { $_.DisplayName -like $filter }
+            }
 
-         # For each item
-         foreach ($item in $items) {
-            # Remove the item
-            Invoke-FabricAPIRequest -Uri "workspaces/$workspaceId/items/$($item.ID)" -Method Delete
-         }
-      }
-   }
+            # For each item
+            foreach ($item in $items) {
+                # Remove the item
+                Invoke-FabricAPIRequest -Uri "workspaces/$workspaceId/items/$($item.ID)" -Method Delete
+            }
+        }
+    }
 }

--- a/source/Public/KQL Dashboard/Get-FabricKQLDashboard.ps1
+++ b/source/Public/KQL Dashboard/Get-FabricKQLDashboard.ps1
@@ -114,13 +114,11 @@ function Get-FabricKQLDashboard {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -130,11 +128,9 @@ function Get-FabricKQLDashboard {
         # Step 8: Filter results based on provided parameters
         $KQLDashboard = if ($KQLDashboardId) {
             $KQLDashboards | Where-Object { $_.Id -eq $KQLDashboardId }
-        }
-        elseif ($KQLDashboardName) {
+        } elseif ($KQLDashboardName) {
             $KQLDashboards | Where-Object { $_.DisplayName -eq $KQLDashboardName }
-        }
-        else {
+        } else {
             # Return all KQLDashboards if no filter is provided
             Write-Message -Message "No filter provided. Returning all KQLDashboards." -Level Debug
             $KQLDashboards
@@ -144,13 +140,11 @@ function Get-FabricKQLDashboard {
         if ($KQLDashboard) {
             Write-Message -Message "KQLDashboard found matching the specified criteria." -Level Debug
             return $KQLDashboard
-        }
-        else {
+        } else {
             Write-Message -Message "No KQLDashboard found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve KQLDashboard. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Dashboard/Get-FabricKQLDashboardDefinition.ps1
+++ b/source/Public/KQL Dashboard/Get-FabricKQLDashboardDefinition.ps1
@@ -4,7 +4,7 @@
 Retrieves the definition of a KQLDashboard from a specific workspace in Microsoft Fabric.
 
 .DESCRIPTION
-This function fetches the KQLDashboard's content or metadata from a workspace. 
+This function fetches the KQLDashboard's content or metadata from a workspace.
 Handles both synchronous and asynchronous operations, with detailed logging and error handling.
 
 .PARAMETER WorkspaceId
@@ -84,37 +84,35 @@ function Get-FabricKQLDashboardDefinition {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
-        
+
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve KQLDashboard. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/KQL Dashboard/New-FabricKQLDashboard.ps1
+++ b/source/Public/KQL Dashboard/New-FabricKQLDashboard.ps1
@@ -3,8 +3,8 @@
 Creates a new KQLDashboard in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function sends a POST request to the Microsoft Fabric API to create a new KQLDashboard 
-in the specified workspace. It supports optional parameters for KQLDashboard description 
+This function sends a POST request to the Microsoft Fabric API to create a new KQLDashboard
+in the specified workspace. It supports optional parameters for KQLDashboard description
 and path definitions for the KQLDashboard content.
 
 .PARAMETER WorkspaceId
@@ -29,7 +29,7 @@ An optional path to the platform-specific definition (e.g., .platform file) to u
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -52,7 +52,7 @@ function New-FabricKQLDashboard {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLDashboardPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLDashboardPathPlatformDefinition
@@ -95,8 +95,7 @@ function New-FabricKQLDashboard {
                     payload     = $KQLDashboardEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in KQLDashboard definition." -Level Error
                 return $null
             }
@@ -120,8 +119,7 @@ function New-FabricKQLDashboard {
                     payload     = $KQLDashboardEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -150,28 +148,27 @@ function New-FabricKQLDashboard {
             }
             202 {
                 Write-Message -Message "KQLDashboard '$KQLDashboardName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -179,8 +176,7 @@ function New-FabricKQLDashboard {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create KQLDashboard. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Dashboard/Remove-FabricKQLDashboard.ps1
+++ b/source/Public/KQL Dashboard/Remove-FabricKQLDashboard.ps1
@@ -20,7 +20,7 @@ Deletes the KQLDashboard with ID "67890" from workspace "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Validates token expiration before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -63,9 +63,8 @@ function Remove-FabricKQLDashboard {
             return $null
         }
         Write-Message -Message "KQLDashboard '$KQLDashboardId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete KQLDashboard '$KQLDashboardId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Dashboard/Update-FabricKQLDashboard.ps1
+++ b/source/Public/KQL Dashboard/Update-FabricKQLDashboard.ps1
@@ -1,5 +1,5 @@
 function Update-FabricKQLDashboard {
-<#
+    <#
 .SYNOPSIS
 Updates the properties of a Fabric KQLDashboard.
 
@@ -34,7 +34,7 @@ Updates both the name and description of the KQLDashboard "KQLDashboard123".
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -100,8 +100,7 @@ Author: Tiago Balabuch
         # Step 6: Handle results
         Write-Message -Message "KQLDashboard '$KQLDashboardName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update KQLDashboard. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Dashboard/Update-FabricKQLDashboardDefinition.ps1
+++ b/source/Public/KQL Dashboard/Update-FabricKQLDashboardDefinition.ps1
@@ -3,7 +3,7 @@
 Updates the definition of a KQLDashboard in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function allows updating the content or metadata of a KQLDashboard in a Microsoft Fabric workspace. 
+This function allows updating the content or metadata of a KQLDashboard in a Microsoft Fabric workspace.
 The KQLDashboard content can be provided as file paths, and metadata updates can optionally be enabled.
 
 .PARAMETER WorkspaceId
@@ -25,7 +25,7 @@ Update-FabricKQLDashboardDefinition -WorkspaceId "12345" -KQLDashboardId "67890"
 Updates the content of the KQLDashboard with ID `67890` in the workspace `12345` using the specified KQLDashboard file.
 
 .EXAMPLE
-Update-FabricKQLDashboardDefinition -WorkspaceId "12345" -KQLDashboardId "67890" -KQLDashboardPathDefinition "C:\KQLDashboards\KQLDashboard.ipynb" 
+Update-FabricKQLDashboardDefinition -WorkspaceId "12345" -KQLDashboardId "67890" -KQLDashboardPathDefinition "C:\KQLDashboards\KQLDashboard.ipynb"
 
 Updates both the content and metadata of the KQLDashboard with ID `67890` in the workspace `12345`.
 
@@ -35,7 +35,7 @@ Updates both the content and metadata of the KQLDashboard with ID `67890` in the
 - The KQLDashboard content is encoded as Base64 before being sent to the Fabric API.
 - This function handles asynchronous operations and retrieves operation results if required.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -53,7 +53,7 @@ function Update-FabricKQLDashboardDefinition {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLDashboardPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLDashboardPathPlatformDefinition
@@ -68,8 +68,8 @@ function Update-FabricKQLDashboardDefinition {
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/KQLDashboards/{2}/updateDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $KQLDashboardId
 
-        if($KQLDashboardPathPlatformDefinition){
-            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl 
+        if ($KQLDashboardPathPlatformDefinition) {
+            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
@@ -78,12 +78,12 @@ function Update-FabricKQLDashboardDefinition {
             definition = @{
                 format = $null
                 parts  = @()
-            } 
+            }
         }
-      
+
         if ($KQLDashboardPathDefinition) {
             $KQLDashboardEncodedContent = Convert-ToBase64 -filePath $KQLDashboardPathDefinition
-            
+
             if (-not [string]::IsNullOrEmpty($KQLDashboardEncodedContent)) {
                 # Add new part to the parts array
                 $body.definition.parts += @{
@@ -91,8 +91,7 @@ function Update-FabricKQLDashboardDefinition {
                     payload     = $KQLDashboardEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in KQLDashboard definition." -Level Error
                 return $null
             }
@@ -107,8 +106,7 @@ function Update-FabricKQLDashboardDefinition {
                     payload     = $KQLDashboardEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -127,7 +125,7 @@ function Update-FabricKQLDashboardDefinition {
             -ErrorAction Stop `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-       
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             200 {
@@ -142,23 +140,21 @@ function Update-FabricKQLDashboardDefinition {
                 # Handle operation result
                 if ($operationResult.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
-                    
+
                     $result = Get-FabricLongRunningOperationResult -operationId $operationId
                     return $result.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation Failed" -Level Debug
                     return $operationResult.definition.parts
-                }   
-            } 
+                }
+            }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update KQLDashboard. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Database/Get-FabricKQLDatabase.ps1
+++ b/source/Public/KQL Database/Get-FabricKQLDatabase.ps1
@@ -1,5 +1,5 @@
 function Get-FabricKQLDatabase {
-<#
+    <#
 .SYNOPSIS
 Retrieves an KQLDatabase or a list of KQLDatabases from a specified workspace in Microsoft Fabric.
 
@@ -31,7 +31,7 @@ Retrieves all KQLDatabases in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -111,13 +111,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -127,11 +125,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $KQLDatabase = if ($KQLDatabaseId) {
             $KQLDatabases | Where-Object { $_.Id -eq $KQLDatabaseId }
-        }
-        elseif ($KQLDatabaseName) {
+        } elseif ($KQLDatabaseName) {
             $KQLDatabases | Where-Object { $_.DisplayName -eq $KQLDatabaseName }
-        }
-        else {
+        } else {
             # Return all KQLDatabases if no filter is provided
             Write-Message -Message "No filter provided. Returning all KQLDatabases." -Level Debug
             $KQLDatabases
@@ -141,13 +137,11 @@ Author: Tiago Balabuch
         if ($KQLDatabase) {
             Write-Message -Message "KQLDatabase found matching the specified criteria." -Level Debug
             return $KQLDatabase
-        }
-        else {
+        } else {
             Write-Message -Message "No KQLDatabase found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve KQLDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Database/Get-FabricKQLDatabaseDefinition.ps1
+++ b/source/Public/KQL Database/Get-FabricKQLDatabaseDefinition.ps1
@@ -4,7 +4,7 @@
 Retrieves the definition of a KQLDatabase from a specific workspace in Microsoft Fabric.
 
 .DESCRIPTION
-This function fetches the KQLDatabase's content or metadata from a workspace. 
+This function fetches the KQLDatabase's content or metadata from a workspace.
 It supports retrieving KQLDatabase definitions in the Jupyter KQLDatabase (`ipynb`) format.
 Handles both synchronous and asynchronous operations, with detailed logging and error handling.
 
@@ -92,24 +92,23 @@ function Get-FabricKQLDatabaseDefinition {
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-                
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -118,12 +117,11 @@ function Get-FabricKQLDatabaseDefinition {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
-        
+
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve KQLDatabase. Error: $errorDetails" -Level Error
-    } 
+    }
 }

--- a/source/Public/KQL Database/New-FabricKQLDatabase.ps1
+++ b/source/Public/KQL Database/New-FabricKQLDatabase.ps1
@@ -1,5 +1,5 @@
 function New-FabricKQLDatabase {
-<#
+    <#
 .SYNOPSIS
 Creates a new KQLDatabase in a specified Microsoft Fabric workspace.
 
@@ -54,7 +54,7 @@ An optional path to the platform-specific definition (e.g., .platform file) to u
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -139,8 +139,7 @@ Author: Tiago Balabuch
                     payload     = $KQLDatabaseEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in KQLDatabase definition." -Level Error
                 return $null
             }
@@ -156,8 +155,7 @@ Author: Tiago Balabuch
                         payload     = $KQLDatabaseEncodedPlatformContent
                         payloadType = "InlineBase64"
                     }
-                }
-                else {
+                } else {
                     Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                     return $null
                 }
@@ -174,15 +172,13 @@ Author: Tiago Balabuch
                         payload     = $KQLDatabaseEncodedSchemaContent
                         payloadType = "InlineBase64"
                     }
-                }
-                else {
+                } else {
                     Write-Message -Message "Invalid or empty content in schema definition." -Level Error
                     return $null
                 }
             }
 
-        }
-        else {
+        } else {
             if ($KQLDatabaseType -eq "Shortcut") {
                 if (-not $parentEventhouseId) {
                     Write-Message -Message "Error: 'parentEventhouseId' is required for Shortcut type." -Level Error
@@ -281,8 +277,7 @@ Author: Tiago Balabuch
                     Write-Message -Message "Long Running Operation result: $operationResult" -Level Debug
 
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -296,8 +291,7 @@ Author: Tiago Balabuch
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create KQLDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Database/Remove-FabricKQLDatabase.ps1
+++ b/source/Public/KQL Database/Remove-FabricKQLDatabase.ps1
@@ -20,7 +20,7 @@ Deletes the KQLDatabase with ID "67890" from workspace "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Validates token expiration before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -64,9 +64,8 @@ function Remove-FabricKQLDatabase {
             return $null
         }
         Write-Message -Message "KQLDatabase '$KQLDatabaseId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete KQLDatabase '$KQLDatabaseId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Database/Update-FabricKQLDatabase.ps1
+++ b/source/Public/KQL Database/Update-FabricKQLDatabase.ps1
@@ -102,8 +102,7 @@ function Update-FabricKQLDatabase {
         # Step 6: Handle results
         Write-Message -Message "KQLDatabase '$KQLDatabaseName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update KQLDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Database/Update-FabricKQLDatabaseDefinition.ps1
+++ b/source/Public/KQL Database/Update-FabricKQLDatabaseDefinition.ps1
@@ -77,7 +77,7 @@ function Update-FabricKQLDatabaseDefinition {
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/kqlDatabases/{2}/updateDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $KQLDatabaseId
 
-        if($KQLDatabasePathPlatformDefinition){
+        if ($KQLDatabasePathPlatformDefinition) {
             $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
@@ -85,7 +85,7 @@ function Update-FabricKQLDatabaseDefinition {
         # Step 3: Construct the request body
         $body = @{
             definition = @{
-                parts  = @()
+                parts = @()
             }
         }
 
@@ -99,8 +99,7 @@ function Update-FabricKQLDatabaseDefinition {
                     payload     = $KQLDatabaseEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in KQLDatabase definition." -Level Error
                 return $null
             }
@@ -115,8 +114,7 @@ function Update-FabricKQLDatabaseDefinition {
                     payload     = $KQLDatabaseEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -133,8 +131,7 @@ function Update-FabricKQLDatabaseDefinition {
                     payload     = $KQLDatabaseEncodedSchemaContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in schema definition." -Level Error
                 return $null
             }
@@ -181,8 +178,7 @@ function Update-FabricKQLDatabaseDefinition {
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -196,8 +192,7 @@ function Update-FabricKQLDatabaseDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update KQLDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Queryset/Get-FabricKQLQueryset.ps1
+++ b/source/Public/KQL Queryset/Get-FabricKQLQueryset.ps1
@@ -1,5 +1,5 @@
 function Get-FabricKQLQueryset {
-<#
+    <#
 .SYNOPSIS
 Retrieves an KQLQueryset or a list of KQLQuerysets from a specified workspace in Microsoft Fabric.
 
@@ -31,7 +31,7 @@ Retrieves all KQLQuerysets in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -111,13 +111,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -127,11 +125,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $KQLQueryset = if ($KQLQuerysetId) {
             $KQLQuerysets | Where-Object { $_.Id -eq $KQLQuerysetId }
-        }
-        elseif ($KQLQuerysetName) {
+        } elseif ($KQLQuerysetName) {
             $KQLQuerysets | Where-Object { $_.DisplayName -eq $KQLQuerysetName }
-        }
-        else {
+        } else {
             # Return all KQLQuerysets if no filter is provided
             Write-Message -Message "No filter provided. Returning all KQLQuerysets." -Level Debug
             $KQLQuerysets
@@ -141,13 +137,11 @@ Author: Tiago Balabuch
         if ($KQLQueryset) {
             Write-Message -Message "KQLQueryset found matching the specified criteria." -Level Debug
             return $KQLQueryset
-        }
-        else {
+        } else {
             Write-Message -Message "No KQLQueryset found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve KQLQueryset. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Queryset/Get-FabricKQLQuerysetDefinition.ps1
+++ b/source/Public/KQL Queryset/Get-FabricKQLQuerysetDefinition.ps1
@@ -4,7 +4,7 @@
 Retrieves the definition of a KQLQueryset from a specific workspace in Microsoft Fabric.
 
 .DESCRIPTION
-This function fetches the KQLQueryset's content or metadata from a workspace. 
+This function fetches the KQLQueryset's content or metadata from a workspace.
 Handles both synchronous and asynchronous operations, with detailed logging and error handling.
 
 .PARAMETER WorkspaceId
@@ -84,37 +84,35 @@ function Get-FabricKQLQuerysetDefinition {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
-        
+
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve KQLQueryset. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/KQL Queryset/New-FabricKQLQueryset.ps1
+++ b/source/Public/KQL Queryset/New-FabricKQLQueryset.ps1
@@ -3,8 +3,8 @@
 Creates a new KQLQueryset in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function sends a POST request to the Microsoft Fabric API to create a new KQLQueryset 
-in the specified workspace. It supports optional parameters for KQLQueryset description 
+This function sends a POST request to the Microsoft Fabric API to create a new KQLQueryset
+in the specified workspace. It supports optional parameters for KQLQueryset description
 and path definitions for the KQLQueryset content.
 
 .PARAMETER WorkspaceId
@@ -29,7 +29,7 @@ An optional path to the platform-specific definition (e.g., .platform file) to u
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -52,7 +52,7 @@ function New-FabricKQLQueryset {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLQuerysetPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLQuerysetPathPlatformDefinition
@@ -95,8 +95,7 @@ function New-FabricKQLQueryset {
                     payload     = $KQLQuerysetEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in KQLQueryset definition." -Level Error
                 return $null
             }
@@ -120,8 +119,7 @@ function New-FabricKQLQueryset {
                     payload     = $KQLQuerysetEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -150,28 +148,27 @@ function New-FabricKQLQueryset {
             }
             202 {
                 Write-Message -Message "KQLQueryset '$KQLQuerysetName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -179,8 +176,7 @@ function New-FabricKQLQueryset {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create KQLQueryset. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Queryset/Remove-FabricKQLQueryset.ps1
+++ b/source/Public/KQL Queryset/Remove-FabricKQLQueryset.ps1
@@ -64,8 +64,7 @@ function Remove-FabricKQLQueryset {
         }
         Write-Message -Message "KQLQueryset '$KQLQuerysetId' deleted successfully from workspace '$WorkspaceId'." -Level Info
 
-    }
-    catch {
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete KQLQueryset '$KQLQuerysetId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Queryset/Update-FabricKQLQueryset.ps1
+++ b/source/Public/KQL Queryset/Update-FabricKQLQueryset.ps1
@@ -101,8 +101,7 @@ function Update-FabricKQLQueryset {
         # Step 6: Handle results
         Write-Message -Message "KQLQueryset '$KQLQuerysetName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update KQLQueryset. Error: $errorDetails" -Level Error

--- a/source/Public/KQL Queryset/Update-FabricKQLQuerysetDefinition.ps1
+++ b/source/Public/KQL Queryset/Update-FabricKQLQuerysetDefinition.ps1
@@ -3,7 +3,7 @@
 Updates the definition of a KQLQueryset in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function allows updating the content or metadata of a KQLQueryset in a Microsoft Fabric workspace. 
+This function allows updating the content or metadata of a KQLQueryset in a Microsoft Fabric workspace.
 The KQLQueryset content can be provided as file paths, and metadata updates can optionally be enabled.
 
 .PARAMETER WorkspaceId
@@ -25,7 +25,7 @@ Update-FabricKQLQuerysetDefinition -WorkspaceId "12345" -KQLQuerysetId "67890" -
 Updates the content of the KQLQueryset with ID `67890` in the workspace `12345` using the specified KQLQueryset file.
 
 .EXAMPLE
-Update-FabricKQLQuerysetDefinition -WorkspaceId "12345" -KQLQuerysetId "67890" -KQLQuerysetPathDefinition "C:\KQLQuerysets\KQLQueryset.ipynb" 
+Update-FabricKQLQuerysetDefinition -WorkspaceId "12345" -KQLQuerysetId "67890" -KQLQuerysetPathDefinition "C:\KQLQuerysets\KQLQueryset.ipynb"
 
 Updates both the content and metadata of the KQLQueryset with ID `67890` in the workspace `12345`.
 
@@ -35,7 +35,7 @@ Updates both the content and metadata of the KQLQueryset with ID `67890` in the 
 - The KQLQueryset content is encoded as Base64 before being sent to the Fabric API.
 - This function handles asynchronous operations and retrieves operation results if required.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -53,7 +53,7 @@ function Update-FabricKQLQuerysetDefinition {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLQuerysetPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$KQLQuerysetPathPlatformDefinition
@@ -68,8 +68,8 @@ function Update-FabricKQLQuerysetDefinition {
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/kqlQuerysets/{2}/updateDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $KQLQuerysetId
 
-        if($KQLQuerysetPathPlatformDefinition){
-            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl 
+        if ($KQLQuerysetPathPlatformDefinition) {
+            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
@@ -78,12 +78,12 @@ function Update-FabricKQLQuerysetDefinition {
             definition = @{
                 format = $null
                 parts  = @()
-            } 
+            }
         }
-      
+
         if ($KQLQuerysetPathDefinition) {
             $KQLQuerysetEncodedContent = Convert-ToBase64 -filePath $KQLQuerysetPathDefinition
-            
+
             if (-not [string]::IsNullOrEmpty($KQLQuerysetEncodedContent)) {
                 # Add new part to the parts array
                 $body.definition.parts += @{
@@ -91,8 +91,7 @@ function Update-FabricKQLQuerysetDefinition {
                     payload     = $KQLQuerysetEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in KQLQueryset definition." -Level Error
                 return $null
             }
@@ -107,8 +106,7 @@ function Update-FabricKQLQuerysetDefinition {
                     payload     = $KQLQuerysetEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -127,7 +125,7 @@ function Update-FabricKQLQuerysetDefinition {
             -ErrorAction Stop `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-       
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             200 {
@@ -142,23 +140,21 @@ function Update-FabricKQLQuerysetDefinition {
                 # Handle operation result
                 if ($operationResult.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
-                    
+
                     $result = Get-FabricLongRunningOperationResult -operationId $operationId
                     return $result.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation Failed" -Level Debug
                     return $operationResult.definition.parts
-                }   
-            } 
+                }
+            }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update KQLQueryset. Error: $errorDetails" -Level Error

--- a/source/Public/Lakehouse/Get-FabricLakehouse.ps1
+++ b/source/Public/Lakehouse/Get-FabricLakehouse.ps1
@@ -1,5 +1,5 @@
 function Get-FabricLakehouse {
-<#
+    <#
 .SYNOPSIS
 Retrieves an Lakehouse or a list of Lakehouses from a specified workspace in Microsoft Fabric.
 
@@ -31,7 +31,7 @@ Retrieves all Lakehouses in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -111,13 +111,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -127,11 +125,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $lakehouse = if ($LakehouseId) {
             $lakehouses | Where-Object { $_.Id -eq $LakehouseId }
-        }
-        elseif ($LakehouseName) {
+        } elseif ($LakehouseName) {
             $lakehouses | Where-Object { $_.DisplayName -eq $LakehouseName }
-        }
-        else {
+        } else {
             # Return all lakehouses if no filter is provided
             Write-Message -Message "No filter provided. Returning all Lakehouses." -Level Debug
             $lakehouses
@@ -141,13 +137,11 @@ Author: Tiago Balabuch
         if ($Lakehouse) {
             Write-Message -Message "Lakehouse found matching the specified criteria." -Level Debug
             return $Lakehouse
-        }
-        else {
+        } else {
             Write-Message -Message "No Lakehouse found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Lakehouse. Error: $errorDetails" -Level Error

--- a/source/Public/Lakehouse/Get-FabricLakehouseTable.ps1
+++ b/source/Public/Lakehouse/Get-FabricLakehouseTable.ps1
@@ -1,5 +1,5 @@
 function Get-FabricLakehouseTable {
-<#
+    <#
 .SYNOPSIS
 Retrieves tables from a specified Lakehouse in a Fabric workspace.
 
@@ -13,7 +13,7 @@ The ID of the Lakehouse from which to retrieve tables.
 Get-FabricLakehouseTable -WorkspaceId "your-workspace-id" -LakehouseId "your-lakehouse-id"
 This example retrieves all tables from the specified Lakehouse in the specified workspace.
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -86,13 +86,11 @@ This example retrieves all tables from the specified Lakehouse in the specified 
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -102,13 +100,11 @@ This example retrieves all tables from the specified Lakehouse in the specified 
         if ($tables) {
             Write-Message -Message "Tables found in the Lakehouse '$LakehouseId'." -Level Debug
             return $tables
-        }
-        else {
+        } else {
             Write-Message -Message "No tables found matching in the Lakehouse '$LakehouseId'." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Lakehouse. Error: $errorDetails" -Level Error

--- a/source/Public/Lakehouse/Load-FabricLakehouseTable.ps1
+++ b/source/Public/Lakehouse/Load-FabricLakehouseTable.ps1
@@ -1,5 +1,5 @@
 function Load-FabricLakehouseTable {
-<#
+    <#
 .SYNOPSIS
 Loads data into a specified table in a Lakehouse within a Fabric workspace.
 .DESCRIPTION
@@ -30,7 +30,7 @@ This example loads data from a CSV file into the specified table in the Lakehous
 .EXAMPLE
 Load-FabricLakehouseTable -WorkspaceId "your-workspace-id" -LakehouseId "your-lakehouse-id" -TableName "your-table-name" -PathType "Folder" -RelativePath "path/to/your/folder" -FileFormat "Parquet" -Mode "overwrite" -Recursive $true
 This example loads data from a folder into the specified table in the Lakehouse, overwriting any existing data.
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -145,8 +145,7 @@ This example loads data from a folder into the specified table in the Lakehouse,
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Load table '$TableName' operation complete successfully!" -Level Info
                     return $operationStatus
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -162,8 +161,7 @@ This example loads data from a folder into the specified table in the Lakehouse,
 
         # Step 6: Handle results
 
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Lakehouse. Error: $errorDetails" -Level Error

--- a/source/Public/Lakehouse/New-FabricLakehouse.ps1
+++ b/source/Public/Lakehouse/New-FabricLakehouse.ps1
@@ -63,8 +63,8 @@ function New-FabricLakehouse {
 
         # Step 3: Construct the request body
         $body = @{
-            displayName     = $LakehouseName
-            }
+            displayName = $LakehouseName
+        }
 
         if ($LakehouseDescription) {
             $body.description = $LakehouseDescription
@@ -114,8 +114,7 @@ function New-FabricLakehouse {
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
 
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -127,8 +126,7 @@ function New-FabricLakehouse {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create Lakehouse. Error: $errorDetails" -Level Error

--- a/source/Public/Lakehouse/Remove-FabricLakehouse.ps1
+++ b/source/Public/Lakehouse/Remove-FabricLakehouse.ps1
@@ -20,7 +20,7 @@ Deletes the Lakehouse with ID "67890" from workspace "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Validates token expiration before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -63,9 +63,8 @@ function Remove-FabricLakehouse {
             return $null
         }
         Write-Message -Message "Lakehouse '$LakehouseId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete Lakehouse '$LakehouseId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Lakehouse/Start-FabricLakehouseTableMaintenance.ps1
+++ b/source/Public/Lakehouse/Start-FabricLakehouseTableMaintenance.ps1
@@ -1,5 +1,5 @@
 function Start-FabricLakehouseTableMaintenance {
-<#
+    <#
 .SYNOPSIS
     Initiates a table maintenance job for a specified Lakehouse in a Fabric workspace.
 .DESCRIPTION
@@ -41,7 +41,7 @@ function Start-FabricLakehouseTableMaintenance {
 
 .NOTES
 
-#>
+    #>
 
     [CmdletBinding()]
     param (
@@ -106,7 +106,7 @@ function Start-FabricLakehouseTableMaintenance {
         $body = @{
             executionData = @{
                 tableName        = $TableName
-                optimizeSettings = @{}
+                optimizeSettings = @{ }
             }
         }
         if ($lakehouse.properties.PSObject.Properties['defaultSchema'] -and $SchemaName) {
@@ -117,14 +117,14 @@ function Start-FabricLakehouseTableMaintenance {
             $body.executionData.optimizeSettings.vOrder = $IsVOrder
         }
 
-      if ($ColumnsZOrderBy) {
-        # Ensure $ColumnsZOrderBy is an array
-        if (-not ($ColumnsZOrderBy -is [array])) {
-            $ColumnsZOrderBy = $ColumnsZOrderBy -split ","
+        if ($ColumnsZOrderBy) {
+            # Ensure $ColumnsZOrderBy is an array
+            if (-not ($ColumnsZOrderBy -is [array])) {
+                $ColumnsZOrderBy = $ColumnsZOrderBy -split ","
+            }
+            # Add it to the optimizeSettings in the request body
+            $body.executionData.optimizeSettings.zOrderBy = $ColumnsZOrderBy
         }
-        # Add it to the optimizeSettings in the request body
-        $body.executionData.optimizeSettings.zOrderBy = $ColumnsZOrderBy
-    }
 
 
 
@@ -176,8 +176,7 @@ function Start-FabricLakehouseTableMaintenance {
                     $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location -retryAfter $retryAfter
                     Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                     return $operationStatus
-                }
-                else {
+                } else {
                     Write-Message -Message "The operation is running asynchronously." -Level Info
                     Write-Message -Message "Use the returned details to check the operation status." -Level Info
                     Write-Message -Message "To wait for the operation to complete, set the 'waitForCompletion' parameter to true." -Level Info
@@ -195,8 +194,7 @@ function Start-FabricLakehouseTableMaintenance {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to start table maintenance job. Error: $errorDetails" -Level Error

--- a/source/Public/Lakehouse/Update-FabricLakehouse.ps1
+++ b/source/Public/Lakehouse/Update-FabricLakehouse.ps1
@@ -102,8 +102,7 @@ function Update-FabricLakehouse {
         # Step 6: Handle results
         Write-Message -Message "Lakehouse '$LakehouseName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Lakehouse. Error: $errorDetails" -Level Error

--- a/source/Public/ML Experiment/New-FabricMLExperiment.ps1
+++ b/source/Public/ML Experiment/New-FabricMLExperiment.ps1
@@ -3,7 +3,7 @@
     Creates a new ML Experiment in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a POST request to the Microsoft Fabric API to create a new ML Experiment 
+    This function sends a POST request to the Microsoft Fabric API to create a new ML Experiment
     in the specified workspace. It supports optional parameters for ML Experiment description.
 
 .PARAMETER WorkspaceId
@@ -24,7 +24,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function New-FabricMLExperiment {
     [CmdletBinding()]
@@ -85,33 +85,32 @@ function New-FabricMLExperiment {
             }
             202 {
                 Write-Message -Message "ML Experiment '$MLExperimentName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }   
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -121,8 +120,7 @@ function New-FabricMLExperiment {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create ML Experiment. Error: $errorDetails" -Level Error

--- a/source/Public/ML Experiment/Remove-FabricMLExperiment.ps1
+++ b/source/Public/ML Experiment/Remove-FabricMLExperiment.ps1
@@ -3,7 +3,7 @@
     Removes an ML Experiment from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove an ML Experiment 
+    This function sends a DELETE request to the Microsoft Fabric API to remove an ML Experiment
     from the specified workspace using the provided WorkspaceId and MLExperimentId.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Remove-FabricMLExperiment {
     [CmdletBinding()]
@@ -62,9 +62,8 @@ function Remove-FabricMLExperiment {
             return $null
         }
         Write-Message -Message "ML Experiment '$MLExperimentId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete ML Experiment '$MLExperimentId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/ML Experiment/Update-FabricMLExperiment.ps1
+++ b/source/Public/ML Experiment/Update-FabricMLExperiment.ps1
@@ -3,7 +3,7 @@
     Updates an existing ML Experiment in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing ML Experiment 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing ML Experiment
     in the specified workspace. It supports optional parameters for ML Experiment description.
 
 .PARAMETER WorkspaceId
@@ -27,15 +27,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricMLExperiment {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$MLExperimentId,
@@ -96,8 +96,7 @@ function Update-FabricMLExperiment {
         # Step 6: Handle results
         Write-Message -Message "ML Experiment '$MLExperimentName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update ML Experiment. Error: $errorDetails" -Level Error

--- a/source/Public/ML Model/Get-FabricMLModel.ps1
+++ b/source/Public/ML Model/Get-FabricMLModel.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricMLModel {
     [CmdletBinding()]
@@ -61,27 +61,27 @@ function Get-FabricMLModel {
         # Step 3: Initialize variables
         $continuationToken = $null
         $MLModels = @()
-        
+
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces/{1}/mlModels" -f $FabricConfig.BaseUrl, $WorkspaceId
-        
+
 
         do {
             # Step 5: Construct the API URL
             $apiEndpointUrl = $baseApiEndpointUrl
-        
+
             if ($null -ne $continuationToken) {
                 # URL-encode the continuation token
                 $encodedToken = [System.Web.HttpUtility]::UrlEncode($continuationToken)
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
-         
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -91,7 +91,7 @@ function Get-FabricMLModel {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
-         
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -100,38 +100,34 @@ function Get-FabricMLModel {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
-         
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $MLModels += $response.value
-                 
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
         } while ($null -ne $continuationToken)
         Write-Message -Message "Loop finished and all data added to the list" -Level Debug
-       
+
         # Step 8: Filter results based on provided parameters
         $MLModel = if ($MLModelId) {
             $MLModels | Where-Object { $_.Id -eq $MLModelId }
-        }
-        elseif ($MLModelName) {
+        } elseif ($MLModelName) {
             $MLModels | Where-Object { $_.DisplayName -eq $MLModelName }
-        }
-        else {
+        } else {
             # Return all MLModels if no filter is provided
             Write-Message -Message "No filter provided. Returning all MLModels." -Level Debug
             $MLModels
@@ -141,16 +137,14 @@ function Get-FabricMLModel {
         if ($MLModel) {
             Write-Message -Message "ML Model found matching the specified criteria." -Level Debug
             return $MLModel
-        }
-        else {
+        } else {
             Write-Message -Message "No ML Model found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve ML Model. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/ML Model/New-FabricMLModel.ps1
+++ b/source/Public/ML Model/New-FabricMLModel.ps1
@@ -3,7 +3,7 @@
     Creates a new ML Model in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a POST request to the Microsoft Fabric API to create a new ML Model 
+    This function sends a POST request to the Microsoft Fabric API to create a new ML Model
     in the specified workspace. It supports optional parameters for ML Model description.
 
 .PARAMETER WorkspaceId
@@ -24,7 +24,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function New-FabricMLModel {
     [CmdletBinding()]
@@ -85,33 +85,32 @@ function New-FabricMLModel {
             }
             202 {
                 Write-Message -Message "ML Model '$MLModelName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }   
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -121,8 +120,7 @@ function New-FabricMLModel {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create ML Model. Error: $errorDetails" -Level Error

--- a/source/Public/ML Model/Remove-FabricMLModel.ps1
+++ b/source/Public/ML Model/Remove-FabricMLModel.ps1
@@ -3,7 +3,7 @@
     Removes an ML Model from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove an ML Model 
+    This function sends a DELETE request to the Microsoft Fabric API to remove an ML Model
     from the specified workspace using the provided WorkspaceId and MLModelId.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Remove-FabricMLModel {
     [CmdletBinding()]
@@ -62,9 +62,8 @@ function Remove-FabricMLModel {
             return $null
         }
         Write-Message -Message "ML Model '$MLModelId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete ML Model '$MLModelId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/ML Model/Update-FabricMLModel.ps1
+++ b/source/Public/ML Model/Update-FabricMLModel.ps1
@@ -3,7 +3,7 @@
     Updates an existing ML Model in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing ML Model 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing ML Model
     in the specified workspace. It supports optional parameters for ML Model description.
 
 .PARAMETER WorkspaceId
@@ -24,15 +24,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricMLModel {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$MLModelId,
@@ -84,8 +84,7 @@ function Update-FabricMLModel {
         # Step 6: Handle results
         Write-Message -Message "ML Model '$MLModelId' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update ML Model. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Get-FabricMirroredDatabase.ps1
+++ b/source/Public/Mirrored Database/Get-FabricMirroredDatabase.ps1
@@ -1,5 +1,5 @@
 function Get-FabricMirroredDatabase {
-<#
+    <#
 .SYNOPSIS
 Retrieves an MirroredDatabase or a list of MirroredDatabases from a specified workspace in Microsoft Fabric.
 
@@ -31,7 +31,7 @@ Retrieves all MirroredDatabases in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -113,13 +113,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -130,11 +128,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $MirroredDatabase = if ($MirroredDatabaseId) {
             $MirroredDatabases | Where-Object { $_.Id -eq $MirroredDatabaseId }
-        }
-        elseif ($MirroredDatabaseName) {
+        } elseif ($MirroredDatabaseName) {
             $MirroredDatabases | Where-Object { $_.DisplayName -eq $MirroredDatabaseName }
-        }
-        else {
+        } else {
             # Return all MirroredDatabases if no filter is provided
             Write-Message -Message "No filter provided. Returning all MirroredDatabases." -Level Debug
             $MirroredDatabases
@@ -144,13 +140,11 @@ Author: Tiago Balabuch
         if ($MirroredDatabase) {
             Write-Message -Message "MirroredDatabase found matching the specified criteria." -Level Debug
             return $MirroredDatabase
-        }
-        else {
+        } else {
             Write-Message -Message "No MirroredDatabase found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Get-FabricMirroredDatabaseDefinition.ps1
+++ b/source/Public/Mirrored Database/Get-FabricMirroredDatabaseDefinition.ps1
@@ -4,7 +4,7 @@
 Retrieves the definition of a MirroredDatabase from a specific workspace in Microsoft Fabric.
 
 .DESCRIPTION
-This function fetches the MirroredDatabase's content or metadata from a workspace. 
+This function fetches the MirroredDatabase's content or metadata from a workspace.
 Handles both synchronous and asynchronous operations, with detailed logging and error handling.
 
 .PARAMETER WorkspaceId
@@ -73,37 +73,35 @@ function Get-FabricMirroredDatabaseDefinition {
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
-        
+
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve MirroredDatabase. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Mirrored Database/Get-FabricMirroredDatabaseStatus.ps1
+++ b/source/Public/Mirrored Database/Get-FabricMirroredDatabaseStatus.ps1
@@ -1,5 +1,5 @@
 function Get-FabricMirroredDatabaseStatus {
-<#
+    <#
 .SYNOPSIS
 Retrieves the status of a mirrored database in a specified workspace.
 .DESCRIPTION
@@ -12,7 +12,7 @@ the ID of the mirrored database whose status is to be retrieved.
 .EXAMPLE
 Get-FabricMirroredDatabaseStatus -WorkspaceId "your-workspace-id" -MirroredDatabaseId "your-mirrored-database-id"
 This example retrieves the status of a mirrored database with the specified ID in the specified workspace.
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -56,8 +56,7 @@ This example retrieves the status of a mirrored database with the specified ID i
 
         Write-Message -Message "Returning status of MirroredDatabases." -Level Debug
         return $response
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Get-FabricMirroredDatabaseTableStatus.ps1
+++ b/source/Public/Mirrored Database/Get-FabricMirroredDatabaseTableStatus.ps1
@@ -1,5 +1,5 @@
 function Get-FabricMirroredDatabaseTableStatus {
-<#
+    <#
 .SYNOPSIS
 Retrieves the status of tables in a mirrored database.
 .DESCRIPTION
@@ -14,7 +14,7 @@ This example retrieves the status of tables in a mirrored database with the spec
 .NOTES
 The function retrieves the PowerBI access token and makes a POST request to the PowerBI API to retrieve the status of tables in the specified mirrored database. It then returns the 'value' property of the response, which contains the table statuses.
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -86,13 +86,11 @@ The function retrieves the PowerBI access token and makes a POST request to the 
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -103,8 +101,7 @@ The function retrieves the PowerBI access token and makes a POST request to the 
         # Return all Mirrored Database Table Status
         Write-Message -Message "No filter provided. Returning all MirroredDatabases." -Level Debug
         $MirroredDatabaseTableStatus
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/New-FabricMirroredDatabase.ps1
+++ b/source/Public/Mirrored Database/New-FabricMirroredDatabase.ps1
@@ -3,8 +3,8 @@
 Creates a new MirroredDatabase in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function sends a POST request to the Microsoft Fabric API to create a new MirroredDatabase 
-in the specified workspace. It supports optional parameters for MirroredDatabase description 
+This function sends a POST request to the Microsoft Fabric API to create a new MirroredDatabase
+in the specified workspace. It supports optional parameters for MirroredDatabase description
 and path definitions for the MirroredDatabase content.
 
 .PARAMETER WorkspaceId
@@ -29,7 +29,7 @@ An optional path to the platform-specific definition (e.g., .platform file) to u
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -52,7 +52,7 @@ function New-FabricMirroredDatabase {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$MirroredDatabasePathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$MirroredDatabasePathPlatformDefinition
@@ -84,7 +84,7 @@ function New-FabricMirroredDatabase {
                 # Initialize definition if it doesn't exist
                 if (-not $body.definition) {
                     $body.definition = @{
-                          parts  = @()
+                        parts = @()
                     }
                 }
 
@@ -94,8 +94,7 @@ function New-FabricMirroredDatabase {
                     payload     = $MirroredDatabaseEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in MirroredDatabase definition." -Level Error
                 return $null
             }
@@ -119,8 +118,7 @@ function New-FabricMirroredDatabase {
                     payload     = $MirroredDatabaseEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -149,27 +147,26 @@ function New-FabricMirroredDatabase {
             }
             202 {
                 Write-Message -Message "MirroredDatabase '$MirroredDatabaseName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation Failed" -Level Debug
                     return $operationStatus
-                }   
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -177,8 +174,7 @@ function New-FabricMirroredDatabase {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Remove-FabricMirroredDatabase.ps1
+++ b/source/Public/Mirrored Database/Remove-FabricMirroredDatabase.ps1
@@ -62,9 +62,8 @@ function Remove-FabricMirroredDatabase {
             return $null
         }
         Write-Message -Message "MirroredDatabase '$MirroredDatabaseId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete MirroredDatabase '$MirroredDatabaseId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Start-FabricMirroredDatabaseMirroring.ps1
+++ b/source/Public/Mirrored Database/Start-FabricMirroredDatabaseMirroring.ps1
@@ -1,5 +1,5 @@
-function Start-FabricMirroredDatabaseMirroring{
-<#
+function Start-FabricMirroredDatabaseMirroring {
+    <#
 .SYNOPSIS
     Starts the mirroring of a specified mirrored database in a given workspace.
 .DESCRIPTION
@@ -17,7 +17,7 @@ function Start-FabricMirroredDatabaseMirroring{
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
     - This function handles asynchronous operations and retrieves operation results if required.
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -60,8 +60,7 @@ function Start-FabricMirroredDatabaseMirroring{
         # Step 9: Handle results
         Write-Message -Message "Database mirroring started successfully for MirroredDatabaseId: $MirroredDatabaseId" -Level Info
         return
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to start MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Stop-FabricMirroredDatabaseMirroring.ps1
+++ b/source/Public/Mirrored Database/Stop-FabricMirroredDatabaseMirroring.ps1
@@ -1,5 +1,5 @@
-function Stop-FabricMirroredDatabaseMirroring{
-<#
+function Stop-FabricMirroredDatabaseMirroring {
+    <#
 .SYNOPSIS
     Stops the mirroring of a specified mirrored database in a given workspace.
 .DESCRIPTION
@@ -21,7 +21,7 @@ function Stop-FabricMirroredDatabaseMirroring{
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
     - This function handles asynchronous operations and retrieves operation results if required.
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -64,8 +64,7 @@ function Stop-FabricMirroredDatabaseMirroring{
         # Step 9: Handle results
         Write-Message -Message "Database mirroring stopped successfully for MirroredDatabaseId: $MirroredDatabaseId" -Level Info
         return
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to stop MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Update-FabricMirroredDatabase.ps1
+++ b/source/Public/Mirrored Database/Update-FabricMirroredDatabase.ps1
@@ -101,8 +101,7 @@ function Update-FabricMirroredDatabase {
         # Step 6: Handle results
         Write-Message -Message "MirroredDatabase '$MirroredDatabaseName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Database/Update-FabricMirroredDatabaseDefinition.ps1
+++ b/source/Public/Mirrored Database/Update-FabricMirroredDatabaseDefinition.ps1
@@ -3,7 +3,7 @@
 Updates the definition of a MirroredDatabase in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function allows updating the content or metadata of a MirroredDatabase in a Microsoft Fabric workspace. 
+This function allows updating the content or metadata of a MirroredDatabase in a Microsoft Fabric workspace.
 The MirroredDatabase content can be provided as file paths, and metadata updates can optionally be enabled.
 
 .PARAMETER WorkspaceId
@@ -19,7 +19,7 @@ The MirroredDatabase content can be provided as file paths, and metadata updates
 (Optional) The file path to the MirroredDatabase's platform-specific definition file. The content will be encoded as Base64 and sent in the request.
 
 .PARAMETER UpdateMetadata
-(Optional)A boolean flag indicating whether to update the MirroredDatabase's metadata. 
+(Optional)A boolean flag indicating whether to update the MirroredDatabase's metadata.
 Default: `$false`.
 
 .EXAMPLE
@@ -38,7 +38,7 @@ Updates both the content and metadata of the MirroredDatabase with ID `67890` in
 - The MirroredDatabase content is encoded as Base64 before being sent to the Fabric API.
 - This function handles asynchronous operations and retrieves operation results if required.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -56,7 +56,7 @@ function Update-FabricMirroredDatabaseDefinition {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$MirroredDatabasePathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$MirroredDatabasePathPlatformDefinition
@@ -71,21 +71,21 @@ function Update-FabricMirroredDatabaseDefinition {
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/mirroredDatabases/{2}/updateDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $MirroredDatabaseId
 
-        if($MirroredDatabasePathPlatformDefinition){
-            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl 
+        if ($MirroredDatabasePathPlatformDefinition) {
+            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 3: Construct the request body
         $body = @{
             definition = @{
-                parts  = @()
-            } 
+                parts = @()
+            }
         }
-      
+
         if ($MirroredDatabasePathDefinition) {
             $MirroredDatabaseEncodedContent = Convert-ToBase64 -filePath $MirroredDatabasePathDefinition
-            
+
             if (-not [string]::IsNullOrEmpty($MirroredDatabaseEncodedContent)) {
                 # Add new part to the parts array
                 $body.definition.parts += @{
@@ -93,8 +93,7 @@ function Update-FabricMirroredDatabaseDefinition {
                     payload     = $MirroredDatabaseEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in MirroredDatabase definition." -Level Error
                 return $null
             }
@@ -109,8 +108,7 @@ function Update-FabricMirroredDatabaseDefinition {
                     payload     = $MirroredDatabaseEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -129,7 +127,7 @@ function Update-FabricMirroredDatabaseDefinition {
             -ErrorAction Stop `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-       
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             200 {
@@ -144,23 +142,21 @@ function Update-FabricMirroredDatabaseDefinition {
                 # Handle operation result
                 if ($operationResult.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
-                    
+
                     $result = Get-FabricLongRunningOperationResult -operationId $operationId
                     return $result.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation Failed" -Level Debug
                     return $operationResult.definition.parts
-                }   
-            } 
+                }
+            }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update MirroredDatabase. Error: $errorDetails" -Level Error

--- a/source/Public/Mirrored Warehouse/Get-FabricMirroredWarehouse.ps1
+++ b/source/Public/Mirrored Warehouse/Get-FabricMirroredWarehouse.ps1
@@ -1,5 +1,5 @@
 function Get-FabricMirroredWarehouse {
-<#
+    <#
 .SYNOPSIS
 Retrieves an MirroredWarehouse or a list of MirroredWarehouses from a specified workspace in Microsoft Fabric.
 
@@ -31,7 +31,7 @@ Retrieves all MirroredWarehouses in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -113,13 +113,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -130,11 +128,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $MirroredWarehouse = if ($MirroredWarehouseId) {
             $MirroredWarehouses | Where-Object { $_.Id -eq $MirroredWarehouseId }
-        }
-        elseif ($MirroredWarehouseName) {
+        } elseif ($MirroredWarehouseName) {
             $MirroredWarehouses | Where-Object { $_.DisplayName -eq $MirroredWarehouseName }
-        }
-        else {
+        } else {
             # Return all MirroredWarehouses if no filter is provided
             Write-Message -Message "No filter provided. Returning all MirroredWarehouses." -Level Debug
             $MirroredWarehouses
@@ -144,13 +140,11 @@ Author: Tiago Balabuch
         if ($MirroredWarehouse) {
             Write-Message -Message "MirroredWarehouse found matching the specified criteria." -Level Debug
             return $MirroredWarehouse
-        }
-        else {
+        } else {
             Write-Message -Message "No MirroredWarehouse found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve MirroredWarehouse. Error: $errorDetails" -Level Error

--- a/source/Public/Notebook/Get-FabricNotebook.ps1
+++ b/source/Public/Notebook/Get-FabricNotebook.ps1
@@ -1,5 +1,5 @@
 function Get-FabricNotebook {
-<#
+    <#
 .SYNOPSIS
 Retrieves an Notebook or a list of Notebooks from a specified workspace in Microsoft Fabric.
 
@@ -31,7 +31,7 @@ Retrieves all Notebooks in workspace "12345".
 
 Author: Tiago Balabuch
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -112,13 +112,11 @@ Author: Tiago Balabuch
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -128,11 +126,9 @@ Author: Tiago Balabuch
         # Step 8: Filter results based on provided parameters
         $notebook = if ($NotebookId) {
             $notebooks | Where-Object { $_.Id -eq $NotebookId }
-        }
-        elseif ($NotebookName) {
+        } elseif ($NotebookName) {
             $notebooks | Where-Object { $_.DisplayName -eq $NotebookName }
-        }
-        else {
+        } else {
             # Return all notebooks if no filter is provided
             Write-Message -Message "No filter provided. Returning all Notebooks." -Level Debug
             $notebooks
@@ -142,13 +138,11 @@ Author: Tiago Balabuch
         if ($notebook) {
             Write-Message -Message "Notebook found matching the specified criteria." -Level Debug
             return $notebook
-        }
-        else {
+        } else {
             Write-Message -Message "No notebook found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Notebook. Error: $errorDetails" -Level Error

--- a/source/Public/Notebook/Get-FabricNotebookDefinition.ps1
+++ b/source/Public/Notebook/Get-FabricNotebookDefinition.ps1
@@ -4,7 +4,7 @@
 Retrieves the definition of a notebook from a specific workspace in Microsoft Fabric.
 
 .DESCRIPTION
-This function fetches the notebook's content or metadata from a workspace. 
+This function fetches the notebook's content or metadata from a workspace.
 It supports retrieving notebook definitions in the Jupyter Notebook (`ipynb`) format.
 Handles both synchronous and asynchronous operations, with detailed logging and error handling.
 
@@ -88,13 +88,13 @@ function Get-FabricNotebookDefinition {
 
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 #[string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
 
@@ -102,30 +102,28 @@ function Get-FabricNotebookDefinition {
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
-                    $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId 
+
+                    $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
-        
+
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Notebook. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Notebook/New-FabricNotebook.ps1
+++ b/source/Public/Notebook/New-FabricNotebook.ps1
@@ -3,8 +3,8 @@
 Creates a new notebook in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function sends a POST request to the Microsoft Fabric API to create a new notebook 
-in the specified workspace. It supports optional parameters for notebook description 
+This function sends a POST request to the Microsoft Fabric API to create a new notebook
+in the specified workspace. It supports optional parameters for notebook description
 and path definitions for the notebook content.
 
 .PARAMETER WorkspaceId
@@ -29,7 +29,7 @@ An optional path to the platform-specific definition (e.g., .platform file) to u
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -52,7 +52,7 @@ function New-FabricNotebook {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$NotebookPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$NotebookPathPlatformDefinition
@@ -95,8 +95,7 @@ function New-FabricNotebook {
                     payload     = $notebookEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in notebook definition." -Level Error
                 return $null
             }
@@ -120,8 +119,7 @@ function New-FabricNotebook {
                     payload     = $notebookEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -150,33 +148,32 @@ function New-FabricNotebook {
             }
             202 {
                 Write-Message -Message "Notebook '$NotebookName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                } 
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -184,8 +181,7 @@ function New-FabricNotebook {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create notebook. Error: $errorDetails" -Level Error

--- a/source/Public/Notebook/New-FabricNotebookNEW.ps1
+++ b/source/Public/Notebook/New-FabricNotebookNEW.ps1
@@ -3,8 +3,8 @@
 Creates a new notebook in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function sends a POST request to the Microsoft Fabric API to create a new notebook 
-in the specified workspace. It supports optional parameters for notebook description 
+This function sends a POST request to the Microsoft Fabric API to create a new notebook
+in the specified workspace. It supports optional parameters for notebook description
 and path definitions for the notebook content.
 
 .PARAMETER WorkspaceId
@@ -29,7 +29,7 @@ An optional path to the platform-specific definition (e.g., .platform file) to u
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -115,33 +115,32 @@ function New-FabricNotebookNEW {
             }
             202 {
                 Write-Message -Message "Notebook '$NotebookName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
-                $operationStatus = Get-FabricLongRunningOperation -operationId $operationId 
+
+                $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                } 
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
@@ -149,8 +148,7 @@ function New-FabricNotebookNEW {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create notebook. Error: $errorDetails" -Level Error

--- a/source/Public/Notebook/Remove-FabricNotebook.ps1
+++ b/source/Public/Notebook/Remove-FabricNotebook.ps1
@@ -20,7 +20,7 @@ Deletes the Notebook with ID "67890" from workspace "12345".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Validates token expiration before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -63,9 +63,8 @@ function Remove-FabricNotebook {
             return $null
         }
         Write-Message -Message "Notebook '$NotebookId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete notebook '$NotebookId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Notebook/Update-FabricNotebook.ps1
+++ b/source/Public/Notebook/Update-FabricNotebook.ps1
@@ -101,8 +101,7 @@ function Update-FabricNotebook {
         # Step 6: Handle results
         Write-Message -Message "Notebook '$NotebookName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update notebook. Error: $errorDetails" -Level Error

--- a/source/Public/Notebook/Update-FabricNotebookDefinition.ps1
+++ b/source/Public/Notebook/Update-FabricNotebookDefinition.ps1
@@ -3,7 +3,7 @@
 Updates the definition of a notebook in a Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function allows updating the content or metadata of a notebook in a Microsoft Fabric workspace. 
+This function allows updating the content or metadata of a notebook in a Microsoft Fabric workspace.
 The notebook content can be provided as file paths, and metadata updates can optionally be enabled.
 
 .PARAMETER WorkspaceId
@@ -34,7 +34,7 @@ Updates both the content and metadata of the notebook with ID `67890` in the wor
 - The notebook content is encoded as Base64 before being sent to the Fabric API.
 - This function handles asynchronous operations and retrieves operation results if required.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -52,7 +52,7 @@ function Update-FabricNotebookDefinition {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$NotebookPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$NotebookPathPlatformDefinition
@@ -68,7 +68,7 @@ function Update-FabricNotebookDefinition {
         $apiEndpointUrl = "{0}/workspaces/{1}/notebooks/{2}/updateDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $NotebookId
 
         if ($NotebookPathPlatformDefinition) {
-            $apiEndpointUrl += "?updateMetadata=true" -f $apiEndpointUrl 
+            $apiEndpointUrl += "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
@@ -77,12 +77,12 @@ function Update-FabricNotebookDefinition {
             definition = @{
                 format = "ipynb"
                 parts  = @()
-            } 
+            }
         }
-      
+
         if ($NotebookPathDefinition) {
             $notebookEncodedContent = Convert-ToBase64 -filePath $NotebookPathDefinition
-            
+
             if (-not [string]::IsNullOrEmpty($notebookEncodedContent)) {
                 # Add new part to the parts array
                 $body.definition.parts += @{
@@ -90,8 +90,7 @@ function Update-FabricNotebookDefinition {
                     payload     = $notebookEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in notebook definition." -Level Error
                 return $null
             }
@@ -106,8 +105,7 @@ function Update-FabricNotebookDefinition {
                     payload     = $notebookEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -126,7 +124,7 @@ function Update-FabricNotebookDefinition {
             -ErrorAction Stop `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-       
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             200 {
@@ -150,18 +148,17 @@ function Update-FabricNotebookDefinition {
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                } 
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
-            } 
+                }
+            }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
                 Write-Message -Message "Error: $($response.message)" -Level Error
@@ -170,8 +167,7 @@ function Update-FabricNotebookDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update notebook. Error: $errorDetails" -Level Error

--- a/source/Public/Paginated Reports/Update-FabricPaginatedReport.ps1
+++ b/source/Public/Paginated Reports/Update-FabricPaginatedReport.ps1
@@ -3,7 +3,7 @@
     Updates an existing paginated report in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing paginated report 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing paginated report
     in the specified workspace. It supports optional parameters for paginated report description.
 
 .PARAMETER WorkspaceId
@@ -27,15 +27,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricPaginatedReport {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$PaginatedReportId,
@@ -96,8 +96,7 @@ function Update-FabricPaginatedReport {
         # Step 6: Handle results
         Write-Message -Message "Paginated Report '$PaginatedReportName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Paginated Report. Error: $errorDetails" -Level Error

--- a/source/Public/Reflex/Get-FabricReflexDefinition.ps1
+++ b/source/Public/Reflex/Get-FabricReflexDefinition.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricReflexDefinition {
     [CmdletBinding()]
@@ -53,11 +53,11 @@ function Get-FabricReflexDefinition {
 
         # Step 3: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/reflexes/{2}/getDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $ReflexId
-        
+
         if ($ReflexFormat) {
             $apiEndpointUrl = "{0}?format={1}" -f $apiEndpointUrl, $ReflexFormat
         }
-        
+
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 4: Make the API request
@@ -81,30 +81,29 @@ function Get-FabricReflexDefinition {
 
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId, -location $location
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -114,11 +113,10 @@ function Get-FabricReflexDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Reflex. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Reflex/New-FabricReflex.ps1
+++ b/source/Public/Reflex/New-FabricReflex.ps1
@@ -3,7 +3,7 @@
     Creates a new Reflex in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a POST request to the Microsoft Fabric API to create a new Reflex 
+    This function sends a POST request to the Microsoft Fabric API to create a new Reflex
     in the specified workspace. It supports optional parameters for Reflex description and path definitions.
 
 .PARAMETER WorkspaceId
@@ -30,7 +30,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function New-FabricReflex {
     [CmdletBinding()]
@@ -51,7 +51,7 @@ function New-FabricReflex {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$ReflexPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$ReflexPathPlatformDefinition
@@ -81,7 +81,7 @@ function New-FabricReflex {
                 # Initialize definition if it doesn't exist
                 if (-not $body.definition) {
                     $body.definition = @{
-                        parts  = @()
+                        parts = @()
                     }
                 }
 
@@ -91,8 +91,7 @@ function New-FabricReflex {
                     payload     = $ReflexEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in Reflex definition." -Level Error
                 return $null
             }
@@ -105,7 +104,7 @@ function New-FabricReflex {
                 # Initialize definition if it doesn't exist
                 if (-not $body.definition) {
                     $body.definition = @{
-                        parts  = @()
+                        parts = @()
                     }
                 }
 
@@ -115,8 +114,7 @@ function New-FabricReflex {
                     payload     = $ReflexEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -137,9 +135,9 @@ function New-FabricReflex {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
+
         Write-Message -Message "Response Code: $statusCode" -Level Debug
-  
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             201 {
@@ -148,33 +146,32 @@ function New-FabricReflex {
             }
             202 {
                 Write-Message -Message "Reflex '$ReflexName' creation accepted. Provisioning in progress!" -Level Info
-                
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                } 
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }   
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -184,8 +181,7 @@ function New-FabricReflex {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create Reflex. Error: $errorDetails" -Level Error

--- a/source/Public/Reflex/Remove-FabricReflex.ps1
+++ b/source/Public/Reflex/Remove-FabricReflex.ps1
@@ -3,7 +3,7 @@
     Removes an Reflex from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove an Reflex 
+    This function sends a DELETE request to the Microsoft Fabric API to remove an Reflex
     from the specified workspace using the provided WorkspaceId and ReflexId.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Remove-FabricReflex {
     [CmdletBinding()]
@@ -53,8 +53,8 @@ function Remove-FabricReflex {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
-            # Step 4: Handle response
+
+        # Step 4: Handle response
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
             Write-Message -Message "Error: $($response.message)" -Level Error
@@ -63,9 +63,8 @@ function Remove-FabricReflex {
             return $null
         }
 
-        Write-Message -Message "Reflex '$ReflexId' deleted successfully from workspace '$WorkspaceId'." -Level Info  
-    }
-    catch {
+        Write-Message -Message "Reflex '$ReflexId' deleted successfully from workspace '$WorkspaceId'." -Level Info
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete Reflex '$ReflexId'. Error: $errorDetails" -Level Error

--- a/source/Public/Reflex/Update-FabricReflex.ps1
+++ b/source/Public/Reflex/Update-FabricReflex.ps1
@@ -3,7 +3,7 @@
     Updates an existing Reflex in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing Reflex 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing Reflex
     in the specified workspace. It supports optional parameters for Reflex description.
 
 .PARAMETER WorkspaceId
@@ -27,15 +27,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricReflex {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$ReflexId,
@@ -96,8 +96,7 @@ function Update-FabricReflex {
         # Step 6: Handle results
         Write-Message -Message "Reflex '$ReflexName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Reflex. Error: $errorDetails" -Level Error

--- a/source/Public/Report/Get-FabricReport.ps1
+++ b/source/Public/Report/Get-FabricReport.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricReport {
     [CmdletBinding()]
@@ -58,15 +58,15 @@ function Get-FabricReport {
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
-        
+
         # Step 3: Initialize variables
         $continuationToken = $null
         $Reports = @()
-  
+
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces/{1}/reports" -f $FabricConfig.BaseUrl, $WorkspaceId
@@ -81,7 +81,7 @@ function Get-FabricReport {
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
- 
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -91,7 +91,7 @@ function Get-FabricReport {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
- 
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -100,38 +100,34 @@ function Get-FabricReport {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
- 
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $Reports += $response.value
-    
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
         } while ($null -ne $continuationToken)
         Write-Message -Message "Loop finished and all data added to the list" -Level Debug
-       
+
         # Step 8: Filter results based on provided parameters
         $Report = if ($ReportId) {
             $Reports | Where-Object { $_.Id -eq $ReportId }
-        }
-        elseif ($ReportName) {
+        } elseif ($ReportName) {
             $Reports | Where-Object { $_.DisplayName -eq $ReportName }
-        }
-        else {
+        } else {
             # Return all Reports if no filter is provided
             Write-Message -Message "No filter provided. Returning all Reports." -Level Debug
             $Reports
@@ -141,16 +137,14 @@ function Get-FabricReport {
         if ($Report) {
             Write-Message -Message "Report found in the Workspace '$WorkspaceId'." -Level Debug
             return $Report
-        }
-        else {
+        } else {
             Write-Message -Message "No Report found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Report. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Report/Get-FabricReportDefinition.ps1
+++ b/source/Public/Report/Get-FabricReportDefinition.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricReportDefinition {
     [CmdletBinding()]
@@ -53,11 +53,11 @@ function Get-FabricReportDefinition {
 
         # Step 3: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/reports/{2}/getDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $ReportId
-        
+
         if ($ReportFormat) {
             $apiEndpointUrl = "{0}?format={1}" -f $apiEndpointUrl, $ReportFormat
         }
-        
+
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 4: Make the API request
@@ -81,30 +81,29 @@ function Get-FabricReportDefinition {
 
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -114,11 +113,10 @@ function Get-FabricReportDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Report. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Report/Remove-FabricReport.ps1
+++ b/source/Public/Report/Remove-FabricReport.ps1
@@ -3,7 +3,7 @@
     Removes an Report from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove an Report 
+    This function sends a DELETE request to the Microsoft Fabric API to remove an Report
     from the specified workspace using the provided WorkspaceId and ReportId.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Remove-FabricReport {
     [CmdletBinding()]
@@ -53,8 +53,8 @@ function Remove-FabricReport {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
-            # Step 4: Handle response
+
+        # Step 4: Handle response
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
             Write-Message -Message "Error: $($response.message)" -Level Error
@@ -63,9 +63,8 @@ function Remove-FabricReport {
             return $null
         }
 
-        Write-Message -Message "Report '$ReportId' deleted successfully from workspace '$WorkspaceId'." -Level Info  
-    }
-    catch {
+        Write-Message -Message "Report '$ReportId' deleted successfully from workspace '$WorkspaceId'." -Level Info
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete Report '$ReportId'. Error: $errorDetails" -Level Error

--- a/source/Public/Report/Update-FabricReport.ps1
+++ b/source/Public/Report/Update-FabricReport.ps1
@@ -3,7 +3,7 @@
     Updates an existing Report in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing Report 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing Report
     in the specified workspace. It supports optional parameters for Report description.
 
 .PARAMETER WorkspaceId
@@ -27,15 +27,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricReport {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$ReportId,
@@ -96,8 +96,7 @@ function Update-FabricReport {
         # Step 6: Handle results
         Write-Message -Message "Report '$ReportName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Report. Error: $errorDetails" -Level Error

--- a/source/Public/Report/Update-FabricReportDefinition.ps1
+++ b/source/Public/Report/Update-FabricReportDefinition.ps1
@@ -3,7 +3,7 @@
     Updates the definition of an existing Report in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update the definition of an existing Report 
+    This function sends a PATCH request to the Microsoft Fabric API to update the definition of an existing Report
     in the specified workspace. It supports optional parameters for Report definition and platform-specific definition.
 
 .PARAMETER WorkspaceId
@@ -24,7 +24,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricReportDefinition {
     [CmdletBinding()]
@@ -56,14 +56,14 @@ function Update-FabricReportDefinition {
         # Step 3: Construct the request body
         $body = @{
             definition = @{
-                parts  = @()
-            } 
+                parts = @()
+            }
         }
-      
+
         if ($ReportPathDefinition) {
             if (-not $body.definition) {
                 $body.definition = @{
-                    parts  = @()
+                    parts = @()
                 }
             }
             $jsonObjectParts = Get-FileDefinitionParts -sourceDirectory $ReportPathDefinition
@@ -78,8 +78,8 @@ function Update-FabricReportDefinition {
             }
         }
 
-        if($hasPlatformFile -eq $true) {
-            $apiEndpointUrl += "?updateMetadata=true" -f $apiEndpointUrl 
+        if ($hasPlatformFile -eq $true) {
+            $apiEndpointUrl += "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
@@ -97,7 +97,7 @@ function Update-FabricReportDefinition {
             -ErrorAction Stop `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-       
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             200 {
@@ -106,16 +106,16 @@ function Update-FabricReportDefinition {
             }
             202 {
                 Write-Message -Message "Update definition for Report '$ReportId' accepted. Operation in progress!" -Level Info
-                
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
@@ -123,21 +123,19 @@ function Update-FabricReportDefinition {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Update definition operation for Report '$ReportId' succeeded!" -Level Info
                     return $operationStatus
-                } 
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
-            } 
+                }
+            }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Report. Error: $errorDetails" -Level Error

--- a/source/Public/SQL Database/Get-FabricSQLDatabase.ps1
+++ b/source/Public/SQL Database/Get-FabricSQLDatabase.ps1
@@ -1,6 +1,6 @@
 function Get-FabricSQLDatabase {
 
-<#
+    <#
 .SYNOPSIS
     Retrieves Fabric SQLDatabases
 
@@ -43,15 +43,15 @@ function Get-FabricSQLDatabase {
 .NOTES
     Revision History:
         - 2025-03-06 - KNO: Init version of the function
-#>
+    #>
 
 
-[CmdletBinding()]
+    [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$WorkspaceId,
 
-        [Alias("Name","DisplayName")]
+        [Alias("Name", "DisplayName")]
         [string]$SQLDatabaseName,
 
         [Alias("Id")]

--- a/source/Public/SQL Database/New-FabricSQLDatabase.ps1
+++ b/source/Public/SQL Database/New-FabricSQLDatabase.ps1
@@ -3,8 +3,8 @@
 Creates a new SQL Database in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-This function sends a POST request to the Microsoft Fabric API to create a new SQL Database 
-in the specified workspace. It supports optional parameters for SQL Database description 
+This function sends a POST request to the Microsoft Fabric API to create a new SQL Database
+in the specified workspace. It supports optional parameters for SQL Database description
 and path definitions for the SQL Database content.
 
 .PARAMETER WorkspaceId
@@ -18,7 +18,7 @@ An optional description for the SQL Database.
 
 
 .EXAMPLE
- New-FabricSQLDatabase -WorkspaceId "workspace-12345" -Name "NewDatabase" 
+ New-FabricSQLDatabase -WorkspaceId "workspace-12345" -Name "NewDatabase"
 
  .NOTES
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
@@ -29,61 +29,60 @@ Author: Kamil Nowinski
 #>
 
 function New-FabricSQLDatabase {
-  [CmdletBinding()]
-  param (
-      [Parameter(Mandatory = $true)]
-      [ValidateNotNullOrEmpty()]
-      [string]$WorkspaceId,
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$WorkspaceId,
 
-      [Parameter(Mandatory = $true)]
-      [ValidateNotNullOrEmpty()]
-      [ValidatePattern('^[a-zA-Z0-9_]*$')]
-      [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [ValidatePattern('^[a-zA-Z0-9_]*$')]
+        [string]$Name,
 
-      [Parameter(Mandatory = $false)]
-      [ValidateNotNullOrEmpty()]
-      [string]$Description
-  )
+        [Parameter(Mandatory = $false)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Description
+    )
 
-  try {
-      # Step 1: Ensure token validity
-      Test-TokenExpired
+    try {
+        # Step 1: Ensure token validity
+        Test-TokenExpired
 
-      # Step 2: Construct the API URL
-      $apiEndpointUrl = "{0}/workspaces/{1}/sqldatabases" -f $FabricConfig.BaseUrl, $WorkspaceId
-      Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
+        # Step 2: Construct the API URL
+        $apiEndpointUrl = "{0}/workspaces/{1}/sqldatabases" -f $FabricConfig.BaseUrl, $WorkspaceId
+        Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
-      # Step 3: Construct the request body
-      $body = @{
-          displayName     = $Name
-      }
+        # Step 3: Construct the request body
+        $body = @{
+            displayName = $Name
+        }
 
-      if ($Description) {
-          $body.description = $Description
-      }
+        if ($Description) {
+            $body.description = $Description
+        }
 
-      $bodyJson = $body | ConvertTo-Json -Depth 10
-      Write-Message -Message "Request Body: $bodyJson" -Level Debug
+        $bodyJson = $body | ConvertTo-Json -Depth 10
+        Write-Message -Message "Request Body: $bodyJson" -Level Debug
 
-      # Step 4: Make the API request
-      $response = Invoke-RestMethod `
-          -Headers $FabricConfig.FabricHeaders `
-          -Uri $apiEndpointUrl `
-          -Method Post `
-          -Body $bodyJson `
-          -ContentType "application/json" `
-          -ErrorAction Stop `
-          -SkipHttpErrorCheck `
-          -ResponseHeadersVariable "responseHeader" `
-          -StatusCodeVariable "statusCode"
+        # Step 4: Make the API request
+        $response = Invoke-RestMethod `
+            -Headers $FabricConfig.FabricHeaders `
+            -Uri $apiEndpointUrl `
+            -Method Post `
+            -Body $bodyJson `
+            -ContentType "application/json" `
+            -ErrorAction Stop `
+            -SkipHttpErrorCheck `
+            -ResponseHeadersVariable "responseHeader" `
+            -StatusCodeVariable "statusCode"
 
-      # Step 5: Handle and log the response
-      Write-Message "RESPONSE: $response" -Level Debug
-      Test-FabricApiResponse -response $response -responseHeader $responseHeader -statusCode $statusCode -Name $Name -TypeName 'SQL Database'
-  }
-  catch {
-      # Step 6: Handle and log errors
-      $errorDetails = $_.Exception.Message
-      Write-Message -Message "Failed to create SQL Database. Error: $errorDetails" -Level Error
-  }
+        # Step 5: Handle and log the response
+        Write-Message "RESPONSE: $response" -Level Debug
+        Test-FabricApiResponse -response $response -responseHeader $responseHeader -statusCode $statusCode -Name $Name -TypeName 'SQL Database'
+    } catch {
+        # Step 6: Handle and log errors
+        $errorDetails = $_.Exception.Message
+        Write-Message -Message "Failed to create SQL Database. Error: $errorDetails" -Level Error
+    }
 }

--- a/source/Public/SQL Database/Remove-FabricSQLDatabase.ps1
+++ b/source/Public/SQL Database/Remove-FabricSQLDatabase.ps1
@@ -40,7 +40,7 @@ function Remove-FabricSQLDatabase {
         # Step 1: Ensure token validity
         Confirm-FabricAuthToken | Out-Null
         Test-TokenExpired
-  
+
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/sqldatabases/{2}" -f $FabricConfig.BaseUrl, $WorkspaceId, $SQLDatabaseId
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
@@ -62,9 +62,8 @@ function Remove-FabricSQLDatabase {
             return $null
         }
         Write-Message -Message "SQL Database '$SQLDatabaseId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete SQL Database '$SQLDatabaseId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Semantic Model/Get-FabricSemanticModel.ps1
+++ b/source/Public/Semantic Model/Get-FabricSemanticModel.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricSemanticModel {
     [CmdletBinding()]
@@ -58,15 +58,15 @@ function Get-FabricSemanticModel {
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
-        
+
         # Step 3: Initialize variables
         $continuationToken = $null
         $SemanticModels = @()
-  
+
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces/{1}/semanticModels" -f $FabricConfig.BaseUrl, $WorkspaceId
@@ -81,7 +81,7 @@ function Get-FabricSemanticModel {
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
- 
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -91,7 +91,7 @@ function Get-FabricSemanticModel {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
- 
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -100,38 +100,34 @@ function Get-FabricSemanticModel {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
- 
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $SemanticModels += $response.value
-    
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
         } while ($null -ne $continuationToken)
         Write-Message -Message "Loop finished and all data added to the list" -Level Debug
-       
+
         # Step 8: Filter results based on provided parameters
         $SemanticModel = if ($SemanticModelId) {
             $SemanticModels | Where-Object { $_.Id -eq $SemanticModelId }
-        }
-        elseif ($SemanticModelName) {
+        } elseif ($SemanticModelName) {
             $SemanticModels | Where-Object { $_.DisplayName -eq $SemanticModelName }
-        }
-        else {
+        } else {
             # Return all SemanticModels if no filter is provided
             Write-Message -Message "No filter provided. Returning all SemanticModels." -Level Debug
             $SemanticModels
@@ -141,16 +137,14 @@ function Get-FabricSemanticModel {
         if ($SemanticModel) {
             Write-Message -Message "SemanticModel found in the Workspace '$WorkspaceId'." -Level Debug
             return $SemanticModel
-        }
-        else {
+        } else {
             Write-Message -Message "No SemanticModel found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve SemanticModel. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Semantic Model/Get-FabricSemanticModelDefinition.ps1
+++ b/source/Public/Semantic Model/Get-FabricSemanticModelDefinition.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricSemanticModelDefinition {
     [CmdletBinding()]
@@ -54,11 +54,11 @@ function Get-FabricSemanticModelDefinition {
 
         # Step 3: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/semanticModels/{2}/getDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $SemanticModelId
-        
+
         if ($SemanticModelFormat) {
             $apiEndpointUrl = "{0}?format={1}" -f $apiEndpointUrl, $SemanticModelFormat
         }
-        
+
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 4: Make the API request
@@ -82,30 +82,29 @@ function Get-FabricSemanticModelDefinition {
 
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }   
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -115,11 +114,10 @@ function Get-FabricSemanticModelDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve SemanticModel. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Semantic Model/Remove-FabricSemanticModel.ps1
+++ b/source/Public/Semantic Model/Remove-FabricSemanticModel.ps1
@@ -3,7 +3,7 @@
     Removes an SemanticModel from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove an SemanticModel 
+    This function sends a DELETE request to the Microsoft Fabric API to remove an SemanticModel
     from the specified workspace using the provided WorkspaceId and SemanticModelId.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Remove-FabricSemanticModel {
     [CmdletBinding()]
@@ -53,8 +53,8 @@ function Remove-FabricSemanticModel {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
-            # Step 4: Handle response
+
+        # Step 4: Handle response
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
             Write-Message -Message "Error: $($response.message)" -Level Error
@@ -63,9 +63,8 @@ function Remove-FabricSemanticModel {
             return $null
         }
 
-        Write-Message -Message "SemanticModel '$SemanticModelId' deleted successfully from workspace '$WorkspaceId'." -Level Info  
-    }
-    catch {
+        Write-Message -Message "SemanticModel '$SemanticModelId' deleted successfully from workspace '$WorkspaceId'." -Level Info
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete SemanticModel '$SemanticModelId'. Error: $errorDetails" -Level Error

--- a/source/Public/Semantic Model/Update-FabricSemanticModel.ps1
+++ b/source/Public/Semantic Model/Update-FabricSemanticModel.ps1
@@ -3,7 +3,7 @@
     Updates an existing SemanticModel in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing SemanticModel 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing SemanticModel
     in the specified workspace. It supports optional parameters for SemanticModel description.
 
 .PARAMETER WorkspaceId
@@ -27,15 +27,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricSemanticModel {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$SemanticModelId,
@@ -96,8 +96,7 @@ function Update-FabricSemanticModel {
         # Step 6: Handle results
         Write-Message -Message "SemanticModel '$SemanticModelName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update SemanticModel. Error: $errorDetails" -Level Error

--- a/source/Public/Semantic Model/Update-FabricSemanticModelDefinition.ps1
+++ b/source/Public/Semantic Model/Update-FabricSemanticModelDefinition.ps1
@@ -3,7 +3,7 @@
     Updates the definition of an existing SemanticModel in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update the definition of an existing SemanticModel 
+    This function sends a PATCH request to the Microsoft Fabric API to update the definition of an existing SemanticModel
     in the specified workspace. It supports optional parameters for SemanticModel definition and platform-specific definition.
 
 .PARAMETER WorkspaceId
@@ -24,7 +24,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricSemanticModelDefinition {
     [CmdletBinding()]
@@ -54,9 +54,9 @@ function Update-FabricSemanticModelDefinition {
         $body = @{
             definition = @{
                 parts = @()
-            } 
+            }
         }
-      
+
         $jsonObjectParts = Get-FileDefinitionParts -sourceDirectory $SemanticModelPathDefinition
         # Add new part to the parts array
         $body.definition.parts = $jsonObjectParts.parts
@@ -69,7 +69,7 @@ function Update-FabricSemanticModelDefinition {
         }
 
         if ($hasPlatformFile -eq $true) {
-            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl 
+            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
@@ -87,7 +87,7 @@ function Update-FabricSemanticModelDefinition {
             -ErrorAction Stop `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-       
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             200 {
@@ -96,16 +96,16 @@ function Update-FabricSemanticModelDefinition {
             }
             202 {
                 Write-Message -Message "Update definition for SemanticModel '$SemanticModelId' accepted. Operation in progress!" -Level Info
-                
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
@@ -113,21 +113,19 @@ function Update-FabricSemanticModelDefinition {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Update definition operation for Semantic Model '$SemanticModelId' succeeded!" -Level Info
                     return $operationStatus
-                } 
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
-            } 
+                }
+            }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode" -Level Error
                 Write-Message -Message "Error details: $($response.message)" -Level Error
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update SemanticModel. Error: $errorDetails" -Level Error

--- a/source/Public/Set-FabricAuthToken.ps1
+++ b/source/Public/Set-FabricAuthToken.ps1
@@ -1,5 +1,5 @@
 function Set-FabricAuthToken {
-<#
+    <#
 .SYNOPSIS
    Sets the Fabric authentication token.
 
@@ -41,66 +41,64 @@ function Set-FabricAuthToken {
 .NOTES
    This function was originally written by Rui Romano.
    https://github.com/RuiRomano/fabricps-pbip
-#>
+    #>
 
-   [CmdletBinding(SupportsShouldProcess)]
-   param
-   (
+    [CmdletBinding(SupportsShouldProcess)]
+    param
+    (
         [string]       $servicePrincipalId
-      , [string]       $servicePrincipalSecret
-      , [PSCredential] $credential
-      , [string]       $tenantId
-      , [switch]       $reset
-      , [string]       $apiUrl
-   )
+        , [string]       $servicePrincipalSecret
+        , [PSCredential] $credential
+        , [string]       $tenantId
+        , [switch]       $reset
+        , [string]       $apiUrl
+    )
 
-   if (!$reset) {
-      $azContext = Get-AzContext
-   }
+    if (!$reset) {
+        $azContext = Get-AzContext
+    }
 
-   if ($apiUrl) {
-      $FabricSession.BaseApiUrl = $apiUrl
-   }
+    if ($apiUrl) {
+        $FabricSession.BaseApiUrl = $apiUrl
+    }
 
-   if (!$azContext) {
-      Write-Output "Getting authentication token"
-      if ($servicePrincipalId) {
-         $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $servicePrincipalId, ($servicePrincipalSecret | ConvertTo-SecureString -AsPlainText -Force)
+    if (!$azContext) {
+        Write-Output "Getting authentication token"
+        if ($servicePrincipalId) {
+            $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $servicePrincipalId, ($servicePrincipalSecret | ConvertTo-SecureString -AsPlainText -Force)
 
-         Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+            Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
 
-         Set-AzContext -Tenant $tenantId | Out-Null
-      }
-      elseif ($null -ne $credential) {
-         Connect-AzAccount -Credential $credential -Tenant $tenantId | Out-Null
-      }
-      else {
-         Connect-AzAccount | Out-Null
-      }
-      $azContext = Get-AzContext
-   }
-   if ($PSCmdlet.ShouldProcess("Setting Fabric authentication token for $($azContext.Account)")) {
-      Write-Output "Connnected: $($azContext.Account)"
-      Write-Output "Fabric ResourceUrl: $($FabricSession.ResourceUrl)"
+            Set-AzContext -Tenant $tenantId | Out-Null
+        } elseif ($null -ne $credential) {
+            Connect-AzAccount -Credential $credential -Tenant $tenantId | Out-Null
+        } else {
+            Connect-AzAccount | Out-Null
+        }
+        $azContext = Get-AzContext
+    }
+    if ($PSCmdlet.ShouldProcess("Setting Fabric authentication token for $($azContext.Account)")) {
+        Write-Output "Connnected: $($azContext.Account)"
+        Write-Output "Fabric ResourceUrl: $($FabricSession.ResourceUrl)"
 
-      $FabricSession.AccessToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $FabricSession.ResourceUrl)
-      $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($FabricSession.AccessToken.Token)
-      $FabricSession.FabricToken = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr))
-      Write-Verbose "Setup headers for API calls"
-      $FabricSession.HeaderParams = @{ Authorization = $FabricSession.AccessToken.Type + ' ' + $FabricSession.FabricToken }
+        $FabricSession.AccessToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $FabricSession.ResourceUrl)
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($FabricSession.AccessToken.Token)
+        $FabricSession.FabricToken = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr))
+        Write-Verbose "Setup headers for API calls"
+        $FabricSession.HeaderParams = @{ Authorization = $FabricSession.AccessToken.Type + ' ' + $FabricSession.FabricToken }
 
-      Write-Output "Azure BaseApiUrl: $($FabricSession.ResourceUrl)"
-      $script:AzureSession.AccessToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $AzureSession.BaseApiUrl)
-      $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AzureSession.AccessToken.Token)
-      $script:AzureSession.Token = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr))
-      $AzureSession.HeaderParams = @{ Authorization = $AzureSession.AccessToken.Type + ' ' + $AzureSession.Token }
+        Write-Output "Azure BaseApiUrl: $($FabricSession.ResourceUrl)"
+        $script:AzureSession.AccessToken = (Get-AzAccessToken -AsSecureString -ResourceUrl $AzureSession.BaseApiUrl)
+        $ssPtr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AzureSession.AccessToken.Token)
+        $script:AzureSession.Token = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($ssPtr))
+        $AzureSession.HeaderParams = @{ Authorization = $AzureSession.AccessToken.Type + ' ' + $AzureSession.Token }
 
-      # Copy session values to exposed $FabricConfig
-      $FabricConfig.TenantIdGlobal = $FabricSession.AccessToken.TenantId
-      $FabricConfig.TokenExpiresOn = $FabricSession.AccessToken.ExpiresOn
-      $FabricConfig.FabricHeaders  = $FabricSession.HeaderParams
+        # Copy session values to exposed $FabricConfig
+        $FabricConfig.TenantIdGlobal = $FabricSession.AccessToken.TenantId
+        $FabricConfig.TokenExpiresOn = $FabricSession.AccessToken.ExpiresOn
+        $FabricConfig.FabricHeaders = $FabricSession.HeaderParams
 
-      return $($FabricSession.FabricToken)
+        return $($FabricSession.FabricToken)
 
-   }
+    }
 }

--- a/source/Public/Spark Job Definition/Get-FabricSparkJobDefinition.ps1
+++ b/source/Public/Spark Job Definition/Get-FabricSparkJobDefinition.ps1
@@ -28,7 +28,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricSparkJobDefinition {
     [CmdletBinding()]
@@ -58,15 +58,15 @@ function Get-FabricSparkJobDefinition {
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
-        
+
         # Step 3: Initialize variables
         $continuationToken = $null
         $SparkJobDefinitions = @()
-  
+
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces/{1}/sparkJobDefinitions" -f $FabricConfig.BaseUrl, $WorkspaceId
@@ -81,7 +81,7 @@ function Get-FabricSparkJobDefinition {
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
- 
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -91,7 +91,7 @@ function Get-FabricSparkJobDefinition {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
- 
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -100,38 +100,34 @@ function Get-FabricSparkJobDefinition {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
- 
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $SparkJobDefinitions += $response.value
-    
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
         } while ($null -ne $continuationToken)
         Write-Message -Message "Loop finished and all data added to the list" -Level Debug
-       
+
         # Step 8: Filter results based on provided parameters
         $SparkJobDefinition = if ($SparkJobDefinitionId) {
             $SparkJobDefinitions | Where-Object { $_.Id -eq $SparkJobDefinitionId }
-        }
-        elseif ($SparkJobDefinitionName) {
+        } elseif ($SparkJobDefinitionName) {
             $SparkJobDefinitions | Where-Object { $_.DisplayName -eq $SparkJobDefinitionName }
-        }
-        else {
+        } else {
             # Return all SparkJobDefinitions if no filter is provided
             Write-Message -Message "No filter provided. Returning all SparkJobDefinitions." -Level Debug
             $SparkJobDefinitions
@@ -141,16 +137,14 @@ function Get-FabricSparkJobDefinition {
         if ($SparkJobDefinition) {
             Write-Message -Message "Spark Job Definition found in the Workspace '$WorkspaceId'." -Level Debug
             return $SparkJobDefinition
-        }
-        else {
+        } else {
             Write-Message -Message "No Spark Job Definition found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve SparkJobDefinition. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Spark Job Definition/Get-FabricSparkJobDefinitionDefinition.ps1
+++ b/source/Public/Spark Job Definition/Get-FabricSparkJobDefinitionDefinition.ps1
@@ -53,11 +53,11 @@ function Get-FabricSparkJobDefinitionDefinition {
 
         # Step 3: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/sparkJobDefinitions/{2}/getDefinition" -f $FabricConfig.BaseUrl, $WorkspaceId, $SparkJobDefinitionId
-        
+
         if ($SparkJobDefinitionFormat) {
             $apiEndpointUrl = "{0}?format={1}" -f $apiEndpointUrl, $SparkJobDefinitionFormat
         }
-        
+
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 4: Make the API request
@@ -81,30 +81,29 @@ function Get-FabricSparkJobDefinitionDefinition {
 
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId, -location $location
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult.definition.parts
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }  
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -114,11 +113,10 @@ function Get-FabricSparkJobDefinitionDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 9: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Spark Job Definition. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Spark Job Definition/New-FabricSparkJobDefinition.ps1
+++ b/source/Public/Spark Job Definition/New-FabricSparkJobDefinition.ps1
@@ -3,7 +3,7 @@
     Creates a new SparkJobDefinition in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a POST request to the Microsoft Fabric API to create a new SparkJobDefinition 
+    This function sends a POST request to the Microsoft Fabric API to create a new SparkJobDefinition
     in the specified workspace. It supports optional parameters for SparkJobDefinition description and path definitions.
 
 .PARAMETER WorkspaceId
@@ -50,7 +50,7 @@ function New-FabricSparkJobDefinition {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$SparkJobDefinitionPathDefinition,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$SparkJobDefinitionPathPlatformDefinition
@@ -91,8 +91,7 @@ function New-FabricSparkJobDefinition {
                     payload     = $SparkJobDefinitionEncodedContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in SparkJobDefinition definition." -Level Error
                 return $null
             }
@@ -116,8 +115,7 @@ function New-FabricSparkJobDefinition {
                     payload     = $SparkJobDefinitionEncodedPlatformContent
                     payloadType = "InlineBase64"
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "Invalid or empty content in platform definition." -Level Error
                 return $null
             }
@@ -138,9 +136,9 @@ function New-FabricSparkJobDefinition {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
+
         Write-Message -Message "Response Code: $statusCode" -Level Debug
-  
+
         # Step 5: Handle and log the response
         switch ($statusCode) {
             201 {
@@ -149,33 +147,32 @@ function New-FabricSparkJobDefinition {
             }
             202 {
                 Write-Message -Message "Spark Job Definition '$SparkJobDefinitionName' creation accepted. Provisioning in progress!" -Level Info
-                
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                } 
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                } 
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -185,8 +182,7 @@ function New-FabricSparkJobDefinition {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create Spark Job Definition. Error: $errorDetails" -Level Error

--- a/source/Public/Spark Job Definition/Remove-FabricSparkJobDefinition.ps1
+++ b/source/Public/Spark Job Definition/Remove-FabricSparkJobDefinition.ps1
@@ -3,7 +3,7 @@
     Removes an SparkJobDefinition from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove an SparkJobDefinition 
+    This function sends a DELETE request to the Microsoft Fabric API to remove an SparkJobDefinition
     from the specified workspace using the provided WorkspaceId and SparkJobDefinitionId.
 
 .PARAMETER WorkspaceId
@@ -52,8 +52,8 @@ function Remove-FabricSparkJobDefinition {
             -SkipHttpErrorCheck `
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
-        
-            # Step 4: Handle response
+
+        # Step 4: Handle response
         if ($statusCode -ne 200) {
             Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
             Write-Message -Message "Error: $($response.message)" -Level Error
@@ -62,9 +62,8 @@ function Remove-FabricSparkJobDefinition {
             return $null
         }
 
-        Write-Message -Message "Spark Job Definition '$SparkJobDefinitionId' deleted successfully from workspace '$WorkspaceId'." -Level Info  
-    }
-    catch {
+        Write-Message -Message "Spark Job Definition '$SparkJobDefinitionId' deleted successfully from workspace '$WorkspaceId'." -Level Info
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete SparkJobDefinition '$SparkJobDefinitionId'. Error: $errorDetails" -Level Error

--- a/source/Public/Spark Job Definition/Start-FabricSparkJobDefinitionOnDemand.ps1
+++ b/source/Public/Spark Job Definition/Start-FabricSparkJobDefinitionOnDemand.ps1
@@ -3,7 +3,7 @@
     Starts a Fabric Spark Job Definition on demand.
 
 .DESCRIPTION
-    This function initiates a Spark Job Definition on demand within a specified workspace. 
+    This function initiates a Spark Job Definition on demand within a specified workspace.
     It constructs the appropriate API endpoint URL and makes a POST request to start the job.
     The function can optionally wait for the job to complete based on the 'waitForCompletion' parameter.
 
@@ -52,7 +52,7 @@ function Start-FabricSparkJobDefinitionOnDemand {
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
-        
+
         # Step 2: Construct the API URL
         $apiEndpointUrl = "{0}/workspaces/{1}/SparkJobDefinitions/{2}/jobs/instances?jobType={3}" -f $FabricConfig.BaseUrl, $WorkspaceId , $SparkJobDefinitionId, $JobType
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
@@ -68,7 +68,7 @@ function Start-FabricSparkJobDefinitionOnDemand {
             -ResponseHeadersVariable "responseHeader" `
             -StatusCodeVariable "statusCode"
 
-        Write-Message -Message "Response Code: $statusCode" -Level Debug    
+        Write-Message -Message "Response Code: $statusCode" -Level Debug
         # Step 5: Handle and log the response
         switch ($statusCode) {
             201 {
@@ -79,22 +79,21 @@ function Start-FabricSparkJobDefinitionOnDemand {
                 Write-Message -Message "Spark Job Definition on demand accepted and is now running in the background. Job execution is in progress." -Level Info
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
-               
+
                 if ($waitForCompletion -eq $true) {
-                    Write-Message -Message "Getting Long Running Operation status" -Level Debug               
+                    Write-Message -Message "Getting Long Running Operation status" -Level Debug
                     $operationStatus = Get-FabricLongRunningOperation -operationId $operationId -location $location -retryAfter $retryAfter
                     Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                     return $operationStatus
-                }
-                else {
+                } else {
                     Write-Message -Message "The operation is running asynchronously." -Level Info
                     Write-Message -Message "Use the returned details to check the operation status." -Level Info
-                    Write-Message -Message "To wait for the operation to complete, set the 'waitForCompletion' parameter to true." -Level Info  
+                    Write-Message -Message "To wait for the operation to complete, set the 'waitForCompletion' parameter to true." -Level Info
                     $operationDetails = [PSCustomObject]@{
                         OperationId = $operationId
                         Location    = $location
@@ -109,8 +108,7 @@ function Start-FabricSparkJobDefinitionOnDemand {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to start Spark Job Definition on demand. Error: $errorDetails" -Level Error

--- a/source/Public/Spark Job Definition/Update-FabricSparkJobDefinition.ps1
+++ b/source/Public/Spark Job Definition/Update-FabricSparkJobDefinition.ps1
@@ -3,7 +3,7 @@
     Updates an existing SparkJobDefinition in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing SparkJobDefinition 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing SparkJobDefinition
     in the specified workspace. It supports optional parameters for SparkJobDefinition description.
 
 .PARAMETER WorkspaceId
@@ -33,8 +33,8 @@ function Update-FabricSparkJobDefinition {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$SparkJobDefinitionId,
@@ -95,8 +95,7 @@ function Update-FabricSparkJobDefinition {
         # Step 6: Handle results
         Write-Message -Message "Spark Job Definition '$SparkJobDefinitionName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update SparkJobDefinition. Error: $errorDetails" -Level Error

--- a/source/Public/Spark/Get-FabricSparkCustomPool.ps1
+++ b/source/Public/Spark/Get-FabricSparkCustomPool.ps1
@@ -66,27 +66,27 @@ function Get-FabricSparkCustomPool {
         # Step 3: Initialize variables
         $continuationToken = $null
         $SparkCustomPools = @()
-        
+
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces/{1}/spark/pools" -f $FabricConfig.BaseUrl, $WorkspaceId
-        
+
 
         do {
             # Step 5: Construct the API URL
             $apiEndpointUrl = $baseApiEndpointUrl
-        
+
             if ($null -ne $continuationToken) {
                 # URL-encode the continuation token
                 $encodedToken = [System.Web.HttpUtility]::UrlEncode($continuationToken)
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
-         
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -96,7 +96,7 @@ function Get-FabricSparkCustomPool {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
-         
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -105,38 +105,34 @@ function Get-FabricSparkCustomPool {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
-         
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $SparkCustomPools += $response.value
-                 
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
         } while ($null -ne $continuationToken)
         Write-Message -Message "Loop finished and all data added to the list" -Level Debug
-       
+
         # Step 8: Filter results based on provided parameters
         $SparkCustomPool = if ($SparkCustomPoolId) {
             $SparkCustomPools | Where-Object { $_.id -eq $SparkCustomPoolId }
-        }
-        elseif ($SparkCustomPoolName) {
+        } elseif ($SparkCustomPoolName) {
             $SparkCustomPools | Where-Object { $_.name -eq $SparkCustomPoolName }
-        }
-        else {
+        } else {
             # Return all SparkCustomPools if no filter is provided
             Write-Message -Message "No filter provided. Returning all SparkCustomPools." -Level Debug
             $SparkCustomPools
@@ -146,16 +142,14 @@ function Get-FabricSparkCustomPool {
         if ($SparkCustomPool) {
             Write-Message -Message "SparkCustomPool found matching the specified criteria." -Level Debug
             return $SparkCustomPool
-        }
-        else {
+        } else {
             Write-Message -Message "No SparkCustomPool found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve SparkCustomPool. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Spark/Get-FabricSparkSettings.ps1
+++ b/source/Public/Spark/Get-FabricSparkSettings.ps1
@@ -18,7 +18,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Get-FabricSparkSettings {
     [CmdletBinding()]
@@ -37,26 +37,26 @@ function Get-FabricSparkSettings {
         # Step 3: Initialize variables
         $continuationToken = $null
         $SparkSettings = @()
-        
+
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces/{1}/spark/settings" -f $FabricConfig.BaseUrl, $WorkspaceId
-        
+
         do {
             # Step 5: Construct the API URL
             $apiEndpointUrl = $baseApiEndpointUrl
-        
+
             if ($null -ne $continuationToken) {
                 # URL-encode the continuation token
                 $encodedToken = [System.Web.HttpUtility]::UrlEncode($continuationToken)
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
-         
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -66,7 +66,7 @@ function Get-FabricSparkSettings {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
-         
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -75,45 +75,41 @@ function Get-FabricSparkSettings {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
-         
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $SparkSettings += $response
-                 
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
         } while ($null -ne $continuationToken)
         Write-Message -Message "Loop finished and all data added to the list" -Level Debug
-       
+
         # Step 9: Handle results
         if ($SparkSettings) {
             Write-Message -Message " Returning all Spark Settings." -Level Debug
-            # Return all Spark Settings 
+            # Return all Spark Settings
             return $SparkSettings
-        }
-        else {
+        } else {
             Write-Message -Message "No SparkSettings found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve SparkSettings. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Spark/New-FabricSparkCustomPool.ps1
+++ b/source/Public/Spark/New-FabricSparkCustomPool.ps1
@@ -3,7 +3,7 @@
     Creates a new Spark custom pool in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a POST request to the Microsoft Fabric API to create a new Spark custom pool 
+    This function sends a POST request to the Microsoft Fabric API to create a new Spark custom pool
     in the specified workspace. It supports various parameters for Spark custom pool configuration.
 
 .PARAMETER WorkspaceId
@@ -45,7 +45,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 
 function New-FabricSparkCustomPool {
@@ -64,7 +64,7 @@ function New-FabricSparkCustomPool {
         [ValidateNotNullOrEmpty()]
         [ValidateSet('MemoryOptimized')]
         [string]$NodeFamily,
-        
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [ValidateSet('Large', 'Medium', 'Small', 'XLarge', 'XXLarge')]
@@ -145,33 +145,32 @@ function New-FabricSparkCustomPool {
             }
             202 {
                 Write-Message -Message "SparkCustomPool '$SparkCustomPoolName' creation accepted. Provisioning in progress!" -Level Info
-               
+
                 [string]$operationId = $responseHeader["x-ms-operation-id"]
                 [string]$location = $responseHeader["Location"]
-                [string]$retryAfter = $responseHeader["Retry-After"] 
+                [string]$retryAfter = $responseHeader["Retry-After"]
 
                 Write-Message -Message "Operation ID: '$operationId'" -Level Debug
                 Write-Message -Message "Location: '$location'" -Level Debug
                 Write-Message -Message "Retry-After: '$retryAfter'" -Level Debug
                 Write-Message -Message "Getting Long Running Operation status" -Level Debug
-               
+
                 $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
                 Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
                 # Handle operation result
                 if ($operationStatus.status -eq "Succeeded") {
                     Write-Message -Message "Operation Succeeded" -Level Debug
                     Write-Message -Message "Getting Long Running Operation result" -Level Debug
-                
+
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId, -location $location
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-                
+
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
-                }   
+                }
             }
             default {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -181,8 +180,7 @@ function New-FabricSparkCustomPool {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create SparkCustomPool. Error: $errorDetails" -Level Error

--- a/source/Public/Spark/Remove-FabricSparkCustomPool.ps1
+++ b/source/Public/Spark/Remove-FabricSparkCustomPool.ps1
@@ -3,7 +3,7 @@
     Removes a Spark custom pool from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove a Spark custom pool 
+    This function sends a DELETE request to the Microsoft Fabric API to remove a Spark custom pool
     from the specified workspace using the provided WorkspaceId and SparkCustomPoolId.
 
 .PARAMETER WorkspaceId
@@ -21,7 +21,7 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Remove-FabricSparkCustomPool {
     [CmdletBinding()]
@@ -62,9 +62,8 @@ function Remove-FabricSparkCustomPool {
             return $null
         }
         Write-Message -Message "Spark Custom Pool '$SparkCustomPoolId' deleted successfully from workspace '$WorkspaceId'." -Level Info
-        
-    }
-    catch {
+
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete SparkCustomPool '$SparkCustomPoolId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Spark/Update-FabricSparkCustomPool.ps1
+++ b/source/Public/Spark/Update-FabricSparkCustomPool.ps1
@@ -3,7 +3,7 @@
     Updates an existing Spark custom pool in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing Spark custom pool 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing Spark custom pool
     in the specified workspace. It supports various parameters for Spark custom pool configuration.
 
 .PARAMETER WorkspaceId
@@ -48,15 +48,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricSparkCustomPool {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$SparkCustomPoolId,
@@ -70,7 +70,7 @@ function Update-FabricSparkCustomPool {
         [ValidateNotNullOrEmpty()]
         [ValidateSet('MemoryOptimized')]
         [string]$NodeFamily,
-        
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [ValidateSet('Large', 'Medium', 'Small', 'XLarge', 'XXLarge')]
@@ -113,14 +113,14 @@ function Update-FabricSparkCustomPool {
 
         # Step 3: Construct the request body
         $body = @{
-                name       = $InstancePoolName
-                nodeFamily = $NodeFamily
-                nodeSize   = $NodeSize
-                autoScale  = @{
-                    enabled      = $AutoScaleEnabled
-                    minNodeCount = $AutoScaleMinNodeCount
-                    maxNodeCount = $AutoScaleMaxNodeCount
-                }
+            name                      = $InstancePoolName
+            nodeFamily                = $NodeFamily
+            nodeSize                  = $NodeSize
+            autoScale                 = @{
+                enabled      = $AutoScaleEnabled
+                minNodeCount = $AutoScaleMinNodeCount
+                maxNodeCount = $AutoScaleMaxNodeCount
+            }
             dynamicExecutorAllocation = @{
                 enabled      = $DynamicExecutorAllocationEnabled
                 minExecutors = $DynamicExecutorAllocationMinExecutors
@@ -155,8 +155,7 @@ function Update-FabricSparkCustomPool {
         # Step 6: Handle results
         Write-Message -Message "Spark Custom Pool '$SparkCustomPoolName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update SparkCustomPool. Error: $errorDetails" -Level Error

--- a/source/Public/Spark/Update-FabricSparkSettings.ps1
+++ b/source/Public/Spark/Update-FabricSparkSettings.ps1
@@ -136,7 +136,7 @@ function Update-FabricSparkSettings {
         # Step 3: Construct the request body
         # Construct the request body with optional properties
 
-        $body = @{}
+        $body = @{ }
 
         if ($PSBoundParameters.ContainsKey('automaticLogEnabled')) {
             $body.automaticLog = @{
@@ -157,12 +157,12 @@ function Update-FabricSparkSettings {
         }
         if ($PSBoundParameters.ContainsKey('defaultPoolName') -or $PSBoundParameters.ContainsKey('defaultPoolType')) {
             if ($PSBoundParameters.ContainsKey('defaultPoolName') -and $PSBoundParameters.ContainsKey('defaultPoolType')) {
-            $body.pool = @{
-                defaultPool = @{
-                name = $defaultPoolName
-                type = $defaultPoolType
+                $body.pool = @{
+                    defaultPool = @{
+                        name = $defaultPoolName
+                        type = $defaultPoolType
+                    }
                 }
-            }
             } else {
                 Write-Message -Message "Both 'defaultPoolName' and 'defaultPoolType' must be provided together." -Level Error
                 throw
@@ -207,8 +207,7 @@ function Update-FabricSparkSettings {
         # Step 6: Handle results
         Write-Message -Message "Spark Custom Pool '$SparkSettingsName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update SparkSettings. Error: $errorDetails" -Level Error

--- a/source/Public/Tenant/Get-FabricCapacityTenantSettingOverrides.ps1
+++ b/source/Public/Tenant/Get-FabricCapacityTenantSettingOverrides.ps1
@@ -52,19 +52,17 @@ function Get-FabricCapacityTenantSettingOverrides {
         $response = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
-            -Method Get 
+            -Method Get
 
         # Step 4: Check if any capacity tenant setting overrides were retrieved and handle results accordingly
         if ($response) {
             Write-Message -Message $message -Level Debug
             return $response
-        }
-        else {
+        } else {
             Write-Message -Message "No capacity tenant setting overrides found." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 5: Log detailed error information if the API request fails
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error retrieving capacity tenant setting overrides: $errorDetails" -Level Error

--- a/source/Public/Tenant/Get-FabricDomainTenantSettingOverrides.ps1
+++ b/source/Public/Tenant/Get-FabricDomainTenantSettingOverrides.ps1
@@ -35,19 +35,17 @@ function Get-FabricDomainTenantSettingOverrides {
         $response = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
-            -Method Get 
+            -Method Get
 
         # Step 4: Check if any domain tenant setting overrides were retrieved and handle results accordingly
         if ($response) {
             Write-Message -Message "Successfully retrieved domain tenant setting overrides." -Level Debug
             return $response
-        }
-        else {
+        } else {
             Write-Message -Message "No domain tenant setting overrides found." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 5: Log detailed error information if the API request fails
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error retrieving domain tenant setting overrides: $errorDetails" -Level Error

--- a/source/Public/Tenant/Get-FabricTenantSetting.ps1
+++ b/source/Public/Tenant/Get-FabricTenantSetting.ps1
@@ -22,7 +22,7 @@ Returns the tenant setting with the title "SomeSetting".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Is-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 
 #>
 
@@ -48,14 +48,13 @@ function Get-FabricTenantSetting {
         $response = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
-            -Method Get 
+            -Method Get
 
         # Step 4: Filter tenant settings based on the provided SettingTitle parameter (if specified)
         $settings = if ($SettingTitle) {
             Write-Message -Message "Filtering tenant settings by title: '$SettingTitle'" -Level Debug
             $response.tenantSettings | Where-Object { $_.title -eq $SettingTitle }
-        }
-        else {
+        } else {
             Write-Message -Message "No filter specified. Retrieving all tenant settings." -Level Debug
             $response.tenantSettings
         }
@@ -64,13 +63,11 @@ function Get-FabricTenantSetting {
         if ($settings) {
             Write-Message -Message "Tenant settings successfully retrieved." -Level Debug
             return $settings
-        }
-        else {
+        } else {
             Write-Message -Message "No tenant settings found matching the specified criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 6: Log detailed error information if the API request fails
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error retrieving tenant settings: $errorDetails" -Level Error

--- a/source/Public/Tenant/Get-FabricTenantSettings.ps1
+++ b/source/Public/Tenant/Get-FabricTenantSettings.ps1
@@ -15,7 +15,7 @@ Retrieves the tenant settings from the Fabric API.
 
 #>
 
-function Get-FabricTenantSettings  {
+function Get-FabricTenantSettings {
     [Alias("Get-FabTenantSettings")]
     Param ()
 

--- a/source/Public/Tenant/Get-FabricWorkspaceTenantSettingOverrides.ps1
+++ b/source/Public/Tenant/Get-FabricWorkspaceTenantSettingOverrides.ps1
@@ -34,19 +34,17 @@ function Get-FabricWorkspaceTenantSettingOverrides {
         $response = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
-            -Method Get 
+            -Method Get
 
         # Step 4: Check if any workspaces tenant setting overrides were retrieved and handle results accordingly
         if ($response) {
             Write-Message -Message "Successfully retrieved workspaces tenant setting overrides." -Level Debug
             return $response
-        }
-        else {
+        } else {
             Write-Message -Message "No workspaces tenant setting overrides found." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 5: Log detailed error information if the API request fails
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error retrieving workspaces tenant setting overrides: $errorDetails" -Level Error

--- a/source/Public/Tenant/Revoke-FabricCapacityTenantSettingOverrides.ps1
+++ b/source/Public/Tenant/Revoke-FabricCapacityTenantSettingOverrides.ps1
@@ -47,12 +47,11 @@ function Revoke-FabricCapacityTenantSettingOverrides {
         $response = Invoke-FabricAPIRequest `
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
-            -Method Delete 
+            -Method Delete
 
         Write-Message -Message "Successfully removed the tenant setting override '$tenantSettingName' from the capacity with ID '$capacityId'." -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 5: Log detailed error information if the API request fails
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error retrieving capacity tenant setting overrides: $errorDetails" -Level Error

--- a/source/Public/Tenant/Update-FabricCapacityTenantSettingOverrides.ps1
+++ b/source/Public/Tenant/Update-FabricCapacityTenantSettingOverrides.ps1
@@ -59,7 +59,7 @@ function Update-FabricCapacityTenantSettingOverrides {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [bool]$DelegateToWorkspace,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.Object]$EnabledSecurityGroups,
@@ -123,14 +123,12 @@ function Update-FabricCapacityTenantSettingOverrides {
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
             -Method Post `
-            -Body $bodyJson  
+            -Body $bodyJson
 
         Write-Message -Message "Successfully updated capacity tenant setting overrides for CapacityId: $CapacityId and SettingTitle: $SettingTitle." -Level Info
         return $response
-    }
-    catch {
+    } catch {
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error updating tenant settings: $errorDetails" -Level Error
     }
 }
-

--- a/source/Public/Tenant/Update-FabricTenantSetting.ps1
+++ b/source/Public/Tenant/Update-FabricTenantSetting.ps1
@@ -63,7 +63,7 @@ function Update-FabricCapacityTenantSettingOverrides {
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [bool]$DelegateToWorkspace,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [System.Object]$EnabledSecurityGroups,
@@ -151,14 +151,12 @@ function Update-FabricCapacityTenantSettingOverrides {
             -BaseURI $apiEndpointURI `
             -Headers $FabricConfig.FabricHeaders `
             -Method Post `
-            -Body $bodyJson  
+            -Body $bodyJson
 
         Write-Message -Message "Successfully updated tenant setting." -Level Info
         return $response
-    }
-    catch {
+    } catch {
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Error updating tenant settings: $errorDetails" -Level Error
     }
 }
-

--- a/source/Public/Users/Get-FabricUserListAccessEntities.ps1
+++ b/source/Public/Users/Get-FabricUserListAccessEntities.ps1
@@ -40,11 +40,11 @@ function Get-FabricUserListAccessEntities {
     )
 
     try {
-   
+
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
-       
+
 
         # Step 4: Loop to retrieve all capacities with continuation token
         $apiEndpointURI = "{0}admin/users/{1}/access" -f $FabricConfig.BaseUrl, $UserId
@@ -58,11 +58,10 @@ function Get-FabricUserListAccessEntities {
             -Method Get
 
         return $response
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Warehouse. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Utils/Convert-FromBase64.ps1
+++ b/source/Public/Utils/Convert-FromBase64.ps1
@@ -1,5 +1,5 @@
 function Convert-FromBase64 {
-<#
+    <#
 .SYNOPSIS
     Decodes a Base64-encoded string into its original text representation.
 
@@ -26,7 +26,7 @@ function Convert-FromBase64 {
 .NOTES
 This function assumes the Base64 input is a valid UTF-8 encoded string.
 Any decoding errors will throw a descriptive error message.
-#>
+    #>
     param (
         [Parameter(Mandatory = $true)]
         [string]$Base64String
@@ -41,8 +41,7 @@ Any decoding errors will throw a descriptive error message.
 
         # Step 3: Return the decoded string
         return $decodedString
-    }
-    catch {
+    } catch {
         # Step 4: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "An error occurred while decoding from Base64: $errorDetails" -Level Error

--- a/source/Public/Utils/Convert-ToBase64.ps1
+++ b/source/Public/Utils/Convert-ToBase64.ps1
@@ -1,5 +1,5 @@
 function Convert-ToBase64 {
-<#
+    <#
 .SYNOPSIS
     Encodes the content of a file into a Base64-encoded string.
 
@@ -29,7 +29,7 @@ function Convert-ToBase64 {
 
 
     Tiago Balabuch
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -50,8 +50,7 @@ function Convert-ToBase64 {
         # Step 3: Return the encoded string
         Write-Message -Message "Return the encoded string for the file: $filePath" -Level Debug
         return $base64String
-    }
-    catch {
+    } catch {
         # Step 4: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "An error occurred while encoding to Base64: $errorDetails" -Level Error

--- a/source/Public/Utils/Get-FabricLongRunningOperation.ps1
+++ b/source/Public/Utils/Get-FabricLongRunningOperation.ps1
@@ -1,5 +1,5 @@
 function Get-FabricLongRunningOperation {
-<#
+    <#
 .SYNOPSIS
 Monitors the status of a long-running operation in Microsoft Fabric.
 
@@ -26,7 +26,7 @@ This command polls the status of the operation with the given operationId every 
 
     AUTHOR
     Tiago Balabuch
-#>
+    #>
     param (
         [Parameter(Mandatory = $false)]
         [string]$operationId,
@@ -42,8 +42,7 @@ This command polls the status of the operation with the given operationId every 
     if ($location) {
         # Use the Location header to define the operationUrl
         $apiEndpointUrl = $location
-    }
-    else {
+    } else {
         $apiEndpointUrl = "https://api.fabric.microsoft.com/v1/operations/{0}" -f $operationId
     }
     Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
@@ -54,8 +53,7 @@ This command polls the status of the operation with the given operationId every 
             # Step 2: Wait before the next request
             if ($retryAfter) {
                 Start-Sleep -Seconds $retryAfter
-            }
-            else {
+            } else {
                 Start-Sleep -Seconds 5  # Default retry interval if no Retry-After header
             }
 
@@ -80,8 +78,7 @@ This command polls the status of the operation with the given operationId every 
 
         # Step 5: Return the operation result
         return $operation
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "An error occurred while checking the operation: $errorDetails" -Level Error

--- a/source/Public/Utils/Get-FabricLongRunningOperationResult.ps1
+++ b/source/Public/Utils/Get-FabricLongRunningOperationResult.ps1
@@ -1,5 +1,5 @@
 function Get-FabricLongRunningOperationResult {
-<#
+    <#
 .SYNOPSIS
 Retrieves the result of a completed long-running operation from the Microsoft Fabric API.
 
@@ -21,7 +21,7 @@ This command fetches the result of the operation with the specified operationId.
 
     AUTHOR
     Tiago Balabuch
-#>
+    #>
     param (
         [Parameter(Mandatory = $true)]
         [string]$operationId
@@ -34,13 +34,13 @@ This command fetches the result of the operation with the specified operationId.
     try {
         # Step 2: Make the API request
         $response = Invoke-RestMethod `
-        -Headers $FabricConfig.FabricHeaders `
-        -Uri $apiEndpointUrl `
-        -Method Get `
-        -ErrorAction Stop `
-        -SkipHttpErrorCheck `
-        -ResponseHeadersVariable "responseHeader" `
-        -StatusCodeVariable "statusCode"
+            -Headers $FabricConfig.FabricHeaders `
+            -Uri $apiEndpointUrl `
+            -Method Get `
+            -ErrorAction Stop `
+            -SkipHttpErrorCheck `
+            -ResponseHeadersVariable "responseHeader" `
+            -StatusCodeVariable "statusCode"
 
 
         # Step 3: Return the result
@@ -56,8 +56,7 @@ This command fetches the result of the operation with the specified operationId.
         }
 
         return $response
-    }
-    catch {
+    } catch {
         # Step 3: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "An error occurred while returning the operation result: $errorDetails" -Level Error

--- a/source/Public/Utils/Invoke-FabricAPIRequest.ps1
+++ b/source/Public/Utils/Invoke-FabricAPIRequest.ps1
@@ -1,6 +1,6 @@
 function Invoke-FabricAPIRequest_duplicate {
 
-<#
+    <#
     .SYNOPSIS
         Sends an HTTP request to a Fabric API endpoint and retrieves the response.
         Takes care of: authentication, 429 throttling, Long-Running-Operation (LRO) response
@@ -46,7 +46,7 @@ function Invoke-FabricAPIRequest_duplicate {
         This function requires the Get-FabricAuthToken function to be defined in the same script or module.
         This function was originally written by Rui Romano.
         https://github.com/RuiRomano/fabricps-pbip
-#>
+    #>
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -82,8 +82,7 @@ function Invoke-FabricAPIRequest_duplicate {
             if ($BaseURI -like "*`?*") {
                 # URI already has parameters, append with &
                 $apiEndpointURI = "$BaseURI&continuationToken=$encodedToken"
-            }
-            else {
+            } else {
                 # No existing parameters, append with ?
                 $apiEndpointURI = "$BaseURI?continuationToken=$encodedToken"
             }
@@ -115,16 +114,13 @@ function Invoke-FabricAPIRequest_duplicate {
                 if ($response) {
                     if ($response.PSObject.Properties.Name -contains 'value') {
                         $results += $response.value
-                    }
-                    elseif ($response.PSObject.Properties.Name -contains 'accessEntities') {
+                    } elseif ($response.PSObject.Properties.Name -contains 'accessEntities') {
                         $results += $response.accessEntities
-                    }
-                    else {
+                    } else {
                         $results += $response
                     }
                     $continuationToken = $response.PSObject.Properties.Match("continuationToken") ? $response.continuationToken : $null
-                }
-                else {
+                } else {
                     Write-Message -Message "No data in response" -Level Debug
                     $continuationToken = $null
                 }
@@ -153,8 +149,7 @@ function Invoke-FabricAPIRequest_duplicate {
                     $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
                     Write-Message -Message "Long Running Operation result: $operationResult" -Level Debug
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
                 }

--- a/source/Public/Utils/Set-FabricApiHeaders.ps1
+++ b/source/Public/Utils/Set-FabricApiHeaders.ps1
@@ -1,5 +1,5 @@
 function Set-FabricApiHeaders {
-<#
+    <#
 .SYNOPSIS
 Sets the Fabric API headers with a valid token for the specified Azure tenant.
 
@@ -36,7 +36,7 @@ Logs in to Azure with the specified tenant ID, retrieves an access token for the
 
      AUTHOR
     Tiago Balabuch
-#>
+    #>
 
     [CmdletBinding()]
     param (
@@ -81,9 +81,9 @@ Logs in to Azure with the specified tenant ID, retrieves an access token for the
             Write-Message -Message "Logging in using the current user" -Level Debug
             Write-Message -Message "Logging in using the current user" -Level Info
             Connect-AzAccount -Tenant $TenantId -ErrorAction Stop | Out-Null
-       }
+        }
 
-       ## Step 4: Retrieve the access token for the Fabric API
+        ## Step 4: Retrieve the access token for the Fabric API
         Write-Message -Message "Retrieve the access token for the Fabric API: $TenantId" -Level Debug
         $fabricToken = Get-AzAccessToken -AsSecureString -ResourceUrl $FabricConfig.ResourceUrl -ErrorAction Stop -WarningAction SilentlyContinue
 
@@ -106,8 +106,7 @@ Logs in to Azure with the specified tenant ID, retrieves an access token for the
         $FabricConfig.TenantIdGlobal = $TenantId
 
         Write-Message -Message "Fabric token successfully configured." -Level Info
-    }
-    catch {
+    } catch {
         # Step 8: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to set Fabric token: $errorDetails" -Level Error

--- a/source/Public/Utils/Test-FabricApiResponse.ps1
+++ b/source/Public/Utils/Test-FabricApiResponse.ps1
@@ -1,5 +1,5 @@
 function Test-FabricApiResponse {
-<#
+    <#
 .SYNOPSIS
 Tests the response from a Fabric API call and handles long-running operations.
 .DESCRIPTION
@@ -29,57 +29,56 @@ Handles the response from a Fabric API call with a 202 status code, indicating t
 - This function is designed to be used within the context of a Fabric API client.
 - It requires the `Write-Message` function to log messages at different levels (Info, Debug, Error).
 - The function handles long-running operations by checking the status of the operation and retrieving the result if it has succeeded.
-#>
+    #>
 
-  [CmdletBinding()]
-  param (
-      [Parameter(Mandatory = $true)]
-      $statusCode,
-      [Parameter(Mandatory = $false)]
-      $response,
-      [Parameter(Mandatory = $false)]
-      $responseHeader,
-      [Parameter(Mandatory = $false)]
-      $Name,
-      [Parameter(Mandatory = $false)]
-      $typeName = 'Fabric Item'
-  )
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        $statusCode,
+        [Parameter(Mandatory = $false)]
+        $response,
+        [Parameter(Mandatory = $false)]
+        $responseHeader,
+        [Parameter(Mandatory = $false)]
+        $Name,
+        [Parameter(Mandatory = $false)]
+        $typeName = 'Fabric Item'
+    )
 
-  switch ($statusCode) {
-    201 {
-        Write-Message -Message "$typeName '$Name' created successfully!" -Level Info
-        return $response
-    }
-    202 {
-        Write-Message -Message "$typeName '$Name' creation accepted. Provisioning in progress!" -Level Info
-
-        [string]$operationId = $responseHeader["x-ms-operation-id"]
-        Write-Message -Message "Operation ID: '$operationId'" -Level Debug
-        Write-Message -Message "Getting Long Running Operation status" -Level Debug
-
-        $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
-        Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
-        # Handle operation result
-        if ($operationStatus.status -eq "Succeeded") {
-            Write-Message -Message "Operation Succeeded" -Level Debug
-            Write-Message -Message "Getting Long Running Operation result" -Level Debug
-
-            $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
-            Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
-
-            return $operationResult
+    switch ($statusCode) {
+        201 {
+            Write-Message -Message "$typeName '$Name' created successfully!" -Level Info
+            return $response
         }
-        else {
-            Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
-            Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
-            return $operationStatus
+        202 {
+            Write-Message -Message "$typeName '$Name' creation accepted. Provisioning in progress!" -Level Info
+
+            [string]$operationId = $responseHeader["x-ms-operation-id"]
+            Write-Message -Message "Operation ID: '$operationId'" -Level Debug
+            Write-Message -Message "Getting Long Running Operation status" -Level Debug
+
+            $operationStatus = Get-FabricLongRunningOperation -operationId $operationId
+            Write-Message -Message "Long Running Operation status: $operationStatus" -Level Debug
+            # Handle operation result
+            if ($operationStatus.status -eq "Succeeded") {
+                Write-Message -Message "Operation Succeeded" -Level Debug
+                Write-Message -Message "Getting Long Running Operation result" -Level Debug
+
+                $operationResult = Get-FabricLongRunningOperationResult -operationId $operationId
+                Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
+
+                return $operationResult
+            } else {
+                Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
+                Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
+                return $operationStatus
+            }
+        }
+        default {
+            Write-Message -Message "Unexpected response code: $statusCode" -Level Error
+            Write-Message -Message "Error details: $($response.message)" -Level Error
+            throw "API request failed with status code $statusCode."
         }
     }
-    default {
-        Write-Message -Message "Unexpected response code: $statusCode" -Level Error
-        Write-Message -Message "Error details: $($response.message)" -Level Error
-        throw "API request failed with status code $statusCode."
-    }
-  }
 
 }

--- a/source/Public/Warehouse/Get-FabricWarehouse.ps1
+++ b/source/Public/Warehouse/Get-FabricWarehouse.ps1
@@ -58,25 +58,23 @@ function Get-FabricWarehouse {
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
         # Step 3: Initialize variables
-        
+
 
         # Step 4: Loop to retrieve all capacities with continuation token
         $apiEndpointURI = "{0}/workspaces/{1}/warehouses" -f $FabricConfig.BaseUrl, $WorkspaceId
-               
-        $Warehouses =  Invoke-FabricAPIRequest `
-        -BaseURI $apiEndpointURI `
-        -Headers $FabricConfig.FabricHeaders `
-        -Method Get `
-        -Body $null
+
+        $Warehouses = Invoke-FabricAPIRequest `
+            -BaseURI $apiEndpointURI `
+            -Headers $FabricConfig.FabricHeaders `
+            -Method Get `
+            -Body $null
 
         # Step 8: Filter results based on provided parameters
         $Warehouse = if ($WarehouseId) {
             $Warehouses | Where-Object { $_.Id -eq $WarehouseId }
-        }
-        elseif ($WarehouseName) {
+        } elseif ($WarehouseName) {
             $Warehouses | Where-Object { $_.DisplayName -eq $WarehouseName }
-        }
-        else {
+        } else {
             # Return all Warehouses if no filter is provided
             Write-Message -Message "No filter provided. Returning all Warehouses." -Level Debug
             $Warehouses
@@ -86,16 +84,14 @@ function Get-FabricWarehouse {
         if ($Warehouse) {
             Write-Message -Message "Warehouse found matching the specified criteria." -Level Debug
             return $Warehouse
-        }
-        else {
+        } else {
             Write-Message -Message "No Warehouse found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve Warehouse. Error: $errorDetails" -Level Error
-    } 
- 
+    }
+
 }

--- a/source/Public/Warehouse/New-FabricWarehouse.ps1
+++ b/source/Public/Warehouse/New-FabricWarehouse.ps1
@@ -3,7 +3,7 @@
     Creates a new warehouse in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a POST request to the Microsoft Fabric API to create a new warehouse 
+    This function sends a POST request to the Microsoft Fabric API to create a new warehouse
     in the specified workspace. It supports optional parameters for warehouse description.
 
 .PARAMETER WorkspaceId
@@ -71,11 +71,10 @@ function New-FabricWarehouse {
             -Method Post `
             -Body $bodyJson
 
-        Write-Message -Message "Data Warehouse created successfully!" -Level Info        
+        Write-Message -Message "Data Warehouse created successfully!" -Level Info
         return $response
-     
-    }
-    catch {
+
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create Warehouse. Error: $errorDetails" -Level Error

--- a/source/Public/Warehouse/Remove-FabricWarehouse.ps1
+++ b/source/Public/Warehouse/Remove-FabricWarehouse.ps1
@@ -3,7 +3,7 @@
     Removes a warehouse from a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a DELETE request to the Microsoft Fabric API to remove a warehouse 
+    This function sends a DELETE request to the Microsoft Fabric API to remove a warehouse
     from the specified workspace using the provided WorkspaceId and WarehouseId.
 
 .PARAMETER WorkspaceId
@@ -48,12 +48,11 @@ function Remove-FabricWarehouse {
             -Headers $FabricConfig.FabricHeaders `
             -BaseURI $apiEndpointURI `
             -Method Delete `
-        
+
         Write-Message -Message "Warehouse '$WarehouseId' deleted successfully from workspace '$WorkspaceId'." -Level Info
         return $response
 
-    }
-    catch {
+    } catch {
         # Step 5: Log and handle errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to delete Warehouse '$WarehouseId' from workspace '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Warehouse/Update-FabricWarehouse.ps1
+++ b/source/Public/Warehouse/Update-FabricWarehouse.ps1
@@ -3,7 +3,7 @@
     Updates an existing warehouse in a specified Microsoft Fabric workspace.
 
 .DESCRIPTION
-    This function sends a PATCH request to the Microsoft Fabric API to update an existing warehouse 
+    This function sends a PATCH request to the Microsoft Fabric API to update an existing warehouse
     in the specified workspace. It supports optional parameters for warehouse description.
 
 .PARAMETER WorkspaceId
@@ -27,15 +27,15 @@
     - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
     Author: Tiago Balabuch
-    
+
 #>
 function Update-FabricWarehouse {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$WorkspaceId,   
-        
+        [string]$WorkspaceId,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$WarehouseId,
@@ -72,18 +72,17 @@ function Update-FabricWarehouse {
         # Convert the body to JSON
         $bodyJson = $body | ConvertTo-Json
         Write-Message -Message "Request Body: $bodyJson" -Level Debug
-        
+
         $response = Invoke-FabricAPIRequest `
-        -Headers $FabricConfig.FabricHeaders `
-        -BaseURI $apiEndpointURI `
-        -Method Patch `
-        -Body $bodyJson 
+            -Headers $FabricConfig.FabricHeaders `
+            -BaseURI $apiEndpointURI `
+            -Method Patch `
+            -Body $bodyJson
 
         # Step 6: Handle results
         Write-Message -Message "Warehouse '$WarehouseName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update Warehouse. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Add-FabricWorkspaceIdentity.ps1
+++ b/source/Public/Workspace/Add-FabricWorkspaceIdentity.ps1
@@ -39,7 +39,7 @@ function Add-FabricWorkspaceIdentity {
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 3: Make the API request
-       $response = Invoke-RestMethod `
+        $response = Invoke-RestMethod `
             -Headers $FabricConfig.FabricHeaders `
             -Uri $apiEndpointUrl `
             -Method Post `
@@ -79,8 +79,7 @@ function Add-FabricWorkspaceIdentity {
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
 
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -92,8 +91,7 @@ function Add-FabricWorkspaceIdentity {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 5: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to provision workspace identity. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Add-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Add-FabricWorkspaceRoleAssignment.ps1
@@ -26,7 +26,7 @@ Assigns the Admin role to the user with ID "principal123" in the workspace "work
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 
 function Add-FabricWorkspaceRoleAssignment {
@@ -93,7 +93,7 @@ function Add-FabricWorkspaceRoleAssignment {
             Write-Message "Error Code: $($response.errorCode)" -Level Error
             return $null
         }
-                
+
         # Step 6: Handle empty response
         if (-not $response) {
             Write-Message -Message "No data returned from the API." -Level Warning
@@ -102,9 +102,8 @@ function Add-FabricWorkspaceRoleAssignment {
 
         Write-Message -Message "Role '$WorkspaceRole' assigned to principal '$PrincipalId' successfully in workspace '$WorkspaceId'." -Level Info
         return $response
-        
-    }
-    catch {
+
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to assign role. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Assign-FabricWorkspaceCapacity.ps1
+++ b/source/Public/Workspace/Assign-FabricWorkspaceCapacity.ps1
@@ -20,7 +20,7 @@ Assigns the workspace with ID "workspace123" to the capacity "capacity456".
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 
 function Assign-FabricWorkspaceCapacity {
@@ -74,8 +74,7 @@ function Assign-FabricWorkspaceCapacity {
             return $null
         }
         Write-Message -Message "Successfully assigned workspace with ID '$WorkspaceId' to capacity with ID '$CapacityId'." -Level Info
-    }
-    catch {
+    } catch {
         # Step 6: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to assign workspace with ID '$WorkspaceId' to capacity with ID '$CapacityId'. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Get-FabricWorkspace.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspace.ps1
@@ -26,7 +26,7 @@ Fetches details of the workspace with the name "MyWorkspace".
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 - Returns the matching workspace details or all workspaces if no filter is provided.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 
 function Get-FabricWorkspace {
@@ -61,7 +61,7 @@ function Get-FabricWorkspace {
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces" -f $FabricConfig.BaseUrl
@@ -75,7 +75,7 @@ function Get-FabricWorkspace {
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
- 
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -85,7 +85,7 @@ function Get-FabricWorkspace {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
- 
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -94,24 +94,22 @@ function Get-FabricWorkspace {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
- 
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $workspaces += $response.value
-         
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -121,27 +119,23 @@ function Get-FabricWorkspace {
         # Step 8: Filter results based on provided parameters
         $workspace = if ($WorkspaceId) {
             $workspaces | Where-Object { $_.Id -eq $WorkspaceId }
-        }
-        elseif ($WorkspaceName) {
+        } elseif ($WorkspaceName) {
             $workspaces | Where-Object { $_.DisplayName -eq $WorkspaceName }
-        }
-        else {
+        } else {
             # Return all workspaces if no filter is provided
             Write-Message -Message "No filter provided. Returning all workspaces." -Level Debug
             $workspaces
         }
-            
+
         # Step 9: Handle results
         if ($workspace) {
             Write-Message -Message "Workspace found matching the specified criteria." -Level Debug
             return $workspace
-        }
-        else {
+        } else {
             Write-Message -Message "No workspace found matching the provided criteria." -Level Warning
             return $null
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve workspace. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Get-FabricWorkspaceDatasetRefreshes.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceDatasetRefreshes.ps1
@@ -1,5 +1,5 @@
 function Get-FabricWorkspaceDatasetRefreshes {
-<#
+    <#
 .SYNOPSIS
    Retrieves the refresh history of all datasets in a specified PowerBI workspace.
 
@@ -23,14 +23,14 @@ function Get-FabricWorkspaceDatasetRefreshes {
 
 .NOTES
    Alias: Get-PowerBIWorkspaceDatasetRefreshes, Get-FabWorkspaceDatasetRefreshes
-#>
+    #>
 
-# Define a function to get the refresh history of all datasets in a PowerBI workspace
+    # Define a function to get the refresh history of all datasets in a PowerBI workspace
     # Set aliases for the function
     [Alias("Get-FabWorkspaceDatasetRefreshes")]
     param(
         # Define a mandatory parameter for the workspace ID
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$WorkspaceID
     )
 

--- a/source/Public/Workspace/Get-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceRoleAssignment.ps1
@@ -25,7 +25,7 @@ Fetches the role assignment with the ID "role123" for the workspace "workspace12
 - Requires `$FabricConfig` global configuration, including `BaseUrl` and `FabricHeaders`.
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
-Author: Tiago Balabuch  
+Author: Tiago Balabuch
 #>
 
 function Get-FabricWorkspaceRoleAssignment {
@@ -45,7 +45,7 @@ function Get-FabricWorkspaceRoleAssignment {
         Write-Message -Message "Validating token..." -Level Debug
         Test-TokenExpired
         Write-Message -Message "Token validation completed." -Level Debug
-    
+
         # Step 3: Initialize variables
         $continuationToken = $null
         $workspaceRoles = @()
@@ -53,22 +53,22 @@ function Get-FabricWorkspaceRoleAssignment {
         if (-not ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq "System.Web" })) {
             Add-Type -AssemblyName System.Web
         }
- 
+
         # Step 4: Loop to retrieve all capacities with continuation token
         Write-Message -Message "Loop started to get continuation token" -Level Debug
         $baseApiEndpointUrl = "{0}/workspaces/{1}/roleAssignments" -f $FabricConfig.BaseUrl, $WorkspaceId
-       
+
         do {
             # Step 5: Construct the API URL
             $apiEndpointUrl = $baseApiEndpointUrl
-        
+
             if ($null -ne $continuationToken) {
                 # URL-encode the continuation token
                 $encodedToken = [System.Web.HttpUtility]::UrlEncode($continuationToken)
                 $apiEndpointUrl = "{0}?continuationToken={1}" -f $apiEndpointUrl, $encodedToken
             }
             Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
-         
+
             # Step 6: Make the API request
             $response = Invoke-RestMethod `
                 -Headers $FabricConfig.FabricHeaders `
@@ -78,7 +78,7 @@ function Get-FabricWorkspaceRoleAssignment {
                 -SkipHttpErrorCheck `
                 -ResponseHeadersVariable "responseHeader" `
                 -StatusCodeVariable "statusCode"
-         
+
             # Step 7: Validate the response code
             if ($statusCode -ne 200) {
                 Write-Message -Message "Unexpected response code: $statusCode from the API." -Level Error
@@ -87,24 +87,22 @@ function Get-FabricWorkspaceRoleAssignment {
                 Write-Message "Error Code: $($response.errorCode)" -Level Error
                 return $null
             }
-         
+
             # Step 8: Add data to the list
             if ($null -ne $response) {
                 Write-Message -Message "Adding data to the list" -Level Debug
                 $workspaceRoles += $response.value
-                 
+
                 # Update the continuation token if present
                 if ($response.PSObject.Properties.Match("continuationToken")) {
                     Write-Message -Message "Updating the continuation token" -Level Debug
                     $continuationToken = $response.continuationToken
                     Write-Message -Message "Continuation token: $continuationToken" -Level Debug
-                }
-                else {
+                } else {
                     Write-Message -Message "Updating the continuation token to null" -Level Debug
                     $continuationToken = $null
                 }
-            }
-            else {
+            } else {
                 Write-Message -Message "No data received from the API." -Level Warning
                 break
             }
@@ -113,8 +111,7 @@ function Get-FabricWorkspaceRoleAssignment {
         # Step 8: Filter results based on provided parameters
         $roleAssignments = if ($WorkspaceRoleAssignmentId) {
             $workspaceRoles | Where-Object { $_.Id -eq $WorkspaceRoleAssignmentId }
-        }
-        else {
+        } else {
             $workspaceRoles
         }
 
@@ -134,18 +131,15 @@ function Get-FabricWorkspaceRoleAssignment {
                 }
             }
             return $results
-        }
-        else {
+        } else {
             if ($WorkspaceRoleAssignmentId) {
                 Write-Message -Message "No role assignment found with ID '$WorkspaceRoleAssignmentId' for WorkspaceId '$WorkspaceId'." -Level Warning
-            }
-            else {
+            } else {
                 Write-Message -Message "No role assignments found for WorkspaceId '$WorkspaceId'." -Level Warning
             }
             return @()
         }
-    }
-    catch {
+    } catch {
         # Step 10: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve role assignments for WorkspaceId '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Get-FabricWorkspaceUsageMetricsData.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceUsageMetricsData.ps1
@@ -1,5 +1,5 @@
 function Get-FabricWorkspaceUsageMetricsData {
-<#
+    <#
 .SYNOPSIS
 Retrieves workspace usage metrics data.
 
@@ -19,9 +19,9 @@ This example retrieves the workspace usage metrics for a specific workspace give
 
 .NOTES
 The function retrieves the PowerBI access token and creates a new usage metrics report. It then defines the names of the reports to retrieve, initializes an empty hashtable to store the reports, and for each report name, retrieves the report and adds it to the hashtable. It then returns the hashtable of reports.
-#>
+    #>
 
-# This function retrieves workspace usage metrics.
+    # This function retrieves workspace usage metrics.
     # Define aliases for the function for flexibility.
     [Alias("Get-FabWorkspaceUsageMetricsData")]
 
@@ -40,18 +40,17 @@ The function retrieves the PowerBI access token and creates a new usage metrics 
     $reportnames = @("'Workspace views'", "'Report pages'", "Users", "Reports", "'Report views'", "'Report page views'", "'Report load times'")
 
     # Initialize an empty hashtable to store the reports.
-    $reports = @{}
+    $reports = @{ }
 
     # For each report name, retrieve the report and add it to the hashtable.
     if ($username -eq "") {
         foreach ($reportname in $reportnames) {
-            $report = Get-FabricUsagemetricsQuery -DatasetID $datasetId -groupId $workspaceId -reportname $reportname
+            $report = Get-FabricUsageMetricsQuery -DatasetID $datasetId -groupId $workspaceId -reportname $reportname
             $reports += @{ $reportname.replace("'", "") = $report }
         }
-    }
-    else {
+    } else {
         foreach ($reportname in $reportnames) {
-            $report = Get-FabricUsagemetricsQuery -DatasetID $datasetId -groupId $workspaceId -reportname $reportname -ImpersonatedUser $username
+            $report = Get-FabricUsageMetricsQuery -DatasetID $datasetId -groupId $workspaceId -reportname $reportname -ImpersonatedUser $username
             $reports += @{ $reportname.replace("'", "") = $report }
         }
     }

--- a/source/Public/Workspace/Get-FabricWorkspaceUsers.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceUsers.ps1
@@ -1,5 +1,5 @@
 function Get-FabricWorkspaceUsers {
-<#
+    <#
 .SYNOPSIS
 Retrieves the users of a workspace.
 
@@ -24,9 +24,9 @@ This example retrieves the users of a workspace given a workspace object.
 
 .NOTES
 The function defines parameters for the workspace ID and workspace object. If the parameter set name is 'WorkspaceId', it retrieves the workspace object. It then makes a GET request to the PowerBI API to retrieve the users of the workspace and returns the 'value' property of the response, which contains the users.
-#>
+    #>
 
-# This function retrieves the users of a workspace.
+    # This function retrieves the users of a workspace.
     # Define aliases for the function for flexibility.
     [Alias("Get-FabWorkspaceUsers")]
 

--- a/source/Public/Workspace/New-FabricWorkspace.ps1
+++ b/source/Public/Workspace/New-FabricWorkspace.ps1
@@ -1,5 +1,5 @@
 function New-FabricWorkspace {
-<#
+    <#
 .SYNOPSIS
 Creates a new Fabric workspace with the specified display name.
 
@@ -25,7 +25,7 @@ Creates a workspace named "NewWorkspace".
 - Calls `Test-TokenExpired` to ensure token validity before making the API request.
 
 Author: Tiago Balabuch
-#>
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -104,8 +104,7 @@ Author: Tiago Balabuch
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
 
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -117,8 +116,7 @@ Author: Tiago Balabuch
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 6: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to create workspace. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/New-FabricWorkspaceUsageMetricsReport.ps1
+++ b/source/Public/Workspace/New-FabricWorkspaceUsageMetricsReport.ps1
@@ -1,5 +1,5 @@
 function New-FabricWorkspaceUsageMetricsReport {
-<#
+    <#
 .SYNOPSIS
 Retrieves the workspace usage metrics dataset ID.
 
@@ -16,9 +16,9 @@ This example retrieves the workspace usage metrics dataset ID for a specific wor
 
 .NOTES
 The function retrieves the PowerBI access token and the Fabric API cluster URI. It then makes a GET request to the Fabric API to retrieve the workspace usage metrics dataset ID, parses the response and replaces certain keys to match the expected format, and returns the 'dbName' property of the first model in the response, which is the dataset ID.
-#>
+    #>
 
-# This function retrieves the workspace usage metrics dataset ID.
+    # This function retrieves the workspace usage metrics dataset ID.
 
     # Define aliases for the function for flexibility.
     [Alias("New-FabWorkspaceUsageMetricsReport")]
@@ -32,7 +32,7 @@ The function retrieves the PowerBI access token and the Fabric API cluster URI. 
     Confirm-FabricAuthToken | Out-Null
 
     # Retrieve the Fabric API cluster URI.
-    $url = get-FabricAPIclusterURI
+    $url = Get-FabricAPIclusterURI
 
     # Make a GET request to the Fabric API to retrieve the workspace usage metrics dataset ID.
     if ($PSCmdlet.ShouldProcess("Workspace Usage Metrics Report", "Retrieve")) {
@@ -42,8 +42,7 @@ The function retrieves the PowerBI access token and the Fabric API cluster URI. 
 
         # Return the 'dbName' property of the first model in the response, which is the dataset ID.
         return $response.models[0].dbName
-    }
-    else {
+    } else {
         return $null
     }
 }

--- a/source/Public/Workspace/Register-FabricWorkspaceToCapacity.ps1
+++ b/source/Public/Workspace/Register-FabricWorkspaceToCapacity.ps1
@@ -1,5 +1,5 @@
 function Register-FabricWorkspaceToCapacity {
-<#
+    <#
 .SYNOPSIS
 Sets a PowerBI workspace to a capacity.
 
@@ -27,11 +27,11 @@ This example Sets the workspace object stored in the $workspace variable to the 
 
 .NOTES
 The function makes a POST request to the PowerBI API to Set the workspace to the capacity. The PowerBI access token is retrieved using the Get-PowerBIAccessToken function.
-#>
+    #>
 
 
-# This function Sets a PowerBI workspace to a capacity.
-# It supports multiple aliases for flexibility.
+    # This function Sets a PowerBI workspace to a capacity.
+    # It supports multiple aliases for flexibility.
     [Alias("Register-FabWorkspaceToCapacity")]
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -67,5 +67,5 @@ The function makes a POST request to the PowerBI API to Set the workspace to the
             #return (Invoke-FabricAPIRequest -Uri "workspaces/$($workspaceID)/assignToCapacity" -Method POST -Body $body).value
             return Invoke-WebRequest -Headers $FabricSession.HeaderParams -Method POST -Uri "$($FabricSession.BaseApiUrl)/workspaces/$($workspaceID)/assignToCapacity" -Body $body
         }
-   }
+    }
 }

--- a/source/Public/Workspace/Remove-FabricWorkspace.ps1
+++ b/source/Public/Workspace/Remove-FabricWorkspace.ps1
@@ -58,8 +58,7 @@ function Remove-FabricWorkspace {
         Write-Message -Message "Workspace '$WorkspaceId' deleted successfully!" -Level Info
         return $null
 
-    }
-    catch {
+    } catch {
         # Step 5: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to retrieve capacity. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Remove-FabricWorkspaceIdentity.ps1
+++ b/source/Public/Workspace/Remove-FabricWorkspaceIdentity.ps1
@@ -39,7 +39,7 @@ function Remove-FabricWorkspaceIdentity {
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 
         # Step 3: Make the API request
-       $response = Invoke-RestMethod `
+        $response = Invoke-RestMethod `
             -Headers $FabricConfig.FabricHeaders `
             -Uri $apiEndpointUrl `
             -Method Post `
@@ -72,8 +72,7 @@ function Remove-FabricWorkspaceIdentity {
                     Write-Message -Message "Long Running Operation status: $operationResult" -Level Debug
 
                     return $operationResult
-                }
-                else {
+                } else {
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Debug
                     Write-Message -Message "Operation failed. Status: $($operationStatus)" -Level Error
                     return $operationStatus
@@ -85,8 +84,7 @@ function Remove-FabricWorkspaceIdentity {
                 throw "API request failed with status code $statusCode."
             }
         }
-    }
-    catch {
+    } catch {
         # Step 5: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to deprovision workspace identity. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Remove-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Remove-FabricWorkspaceRoleAssignment.ps1
@@ -65,8 +65,7 @@ function Remove-FabricWorkspaceRoleAssignment {
         }
 
         Write-Message -Message "Role assignment '$WorkspaceRoleAssignmentId' successfully removed from workspace '$WorkspaceId'." -Level Info
-    }
-    catch {
+    } catch {
         # Step 5: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to remove role assignments for WorkspaceId '$WorkspaceId'. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Unassign-FabricWorkspaceCapacity.ps1
+++ b/source/Public/Workspace/Unassign-FabricWorkspaceCapacity.ps1
@@ -58,8 +58,7 @@ function Unassign-FabricWorkspaceCapacity {
         }
 
         Write-Message -Message "Workspace capacity has been successfully unassigned from workspace '$WorkspaceId'." -Level Info
-    }
-    catch {
+    } catch {
         # Step 5: Capture and log error details
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to unassign workspace from capacity. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Unregister-FabricWorkspaceToCapacity.ps1
+++ b/source/Public/Workspace/Unregister-FabricWorkspaceToCapacity.ps1
@@ -40,7 +40,7 @@ function Unregister-FabricWorkspaceToCapacity {
         [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceObject', ValueFromPipeline = $true)]
         $Workspace
     )
-    
+
     begin {
         Confirm-FabricAuthToken | Out-Null
     }
@@ -49,10 +49,10 @@ function Unregister-FabricWorkspaceToCapacity {
         if ($PSCmdlet.ParameterSetName -eq 'WorkspaceObject') {
             $workspaceid = $workspace.id
         }
-        
+
         if ($PSCmdlet.ShouldProcess("Unassigns workspace $workspaceid from a capacity")) {
             return Invoke-WebRequest -Headers $FabricSession.HeaderParams -Method POST -Uri "$($FabricSession.BaseApiUrl)/workspaces/$($workspaceID)/unassignFromCapacity"
             #return (Invoke-FabricAPIRequest -Uri "workspaces/$workspaceid/unassignFromCapacity" -Method POST).value
         }
-   }
+    }
 }

--- a/source/Public/Workspace/Update-FabricWorkspace.ps1
+++ b/source/Public/Workspace/Update-FabricWorkspace.ps1
@@ -94,8 +94,7 @@ function Update-FabricWorkspace {
         # Step 6: Handle results
         Write-Message -Message "Workspace '$WorkspaceName' updated successfully!" -Level Info
         return $response
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update workspace. Error: $errorDetails" -Level Error

--- a/source/Public/Workspace/Update-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Update-FabricWorkspaceRoleAssignment.ps1
@@ -95,8 +95,7 @@ function Update-FabricWorkspaceRoleAssignment {
         Write-Message -Message "Role assignment $WorkspaceRoleAssignmentId updated successfully in workspace '$WorkspaceId'." -Level Info
         return $response
 
-    }
-    catch {
+    } catch {
         # Step 7: Handle and log errors
         $errorDetails = $_.Exception.Message
         Write-Message -Message "Failed to update role assignment. Error: $errorDetails" -Level Error


### PR DESCRIPTION
Whitespace discussion reminded me - we have `Invoke-DbatoolsFormatter` that helps with getting rid of whitespace and some other things like indentation, brackets being on the same line ... etc..

big PR - but it's from running this:
```PowerShell
gci .\source\Public\ -Recurse -file | % { Invoke-DbatoolsFormatter -Path $_.fullname }
```

and it solved ~40 more tests 

before:
<img width="420" alt="image" src="https://github.com/user-attachments/assets/26179a52-ef61-40d1-a0e4-8359cbd90136" />

after:
<img width="438" alt="image" src="https://github.com/user-attachments/assets/2f1acfaa-90e9-45ac-bba8-f1339c0ba252" />
