### PR TITLE
Update New-WorkspaceName Modified the validation pattern for the WorkspaceName parameter to allow additional special characters. This change enhances flexibility in naming workspaces while maintaining validation integrity.

### DIFF
--- a/source/Public/Workspace/New-FabricWorkspace.ps1
+++ b/source/Public/Workspace/New-FabricWorkspace.ps1
@@ -31,7 +31,7 @@ Author: Tiago Balabuch
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [ValidatePattern('^[a-zA-Z0-9_\- ]*$')]
+        [ValidatePattern("^[a-zA-Z0-9_\-.[]()&,'+!@*$")]
         [string]$WorkspaceName,
 
         [Parameter(Mandatory = $false)]

--- a/source/Public/Workspace/New-FabricWorkspace.ps1
+++ b/source/Public/Workspace/New-FabricWorkspace.ps1
@@ -31,7 +31,6 @@ Author: Tiago Balabuch
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [ValidatePattern("^[a-zA-Z0-9_\-.[]()&,'+!@*$")]
         [string]$WorkspaceName,
 
         [Parameter(Mandatory = $false)]


### PR DESCRIPTION
Close Current workspace name validation too restrictive, doesn't allow common characters #57