### PR TITLE
Add Service Principal parameters for authentication

### DIFF
--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -72,7 +72,7 @@ function Connect-FabricAccount {
             Connect-AzAccount -Credential $credential -Tenant $tenantId | Out-Null
         }
         else {
-            Connect-AzAccount | Out-Null
+            $null = Connect-AzAccount
         }
 
         $azContext = Get-AzContext

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -69,7 +69,7 @@ function Connect-FabricAccount {
             #Set-AzContext -Tenant $tenantId | Out-Null
         }
         elseif ($null -ne $credential) {
-            Connect-AzAccount -Credential $credential -Tenant $tenantId | Out-Null
+            $null = Connect-AzAccount -Credential $credential -Tenant $tenantId
         }
         else {
             $null = Connect-AzAccount

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -76,8 +76,8 @@ function Connect-FabricAccount {
         }
 
         $azContext = Get-AzContext
-         if ($PSCmdlet.ShouldProcess("Setting Fabric authentication token for $($azContext.Account)")) {
-        Write-output "Connected: $($azContext.Account)"
+        if ($PSCmdlet.ShouldProcess("Setting Fabric authentication token for $($azContext.Account)")) {
+            Write-output "Connected: $($azContext.Account)"
         }
 
         Write-Verbose "Get authentication token"

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -5,30 +5,26 @@ function Connect-FabricAccount {
     Connects to the Fabric WebAPI.
 
 .DESCRIPTION
-    Connects to the Fabric WebAPI by using the cmdlet Connect-AzAccount.
-    This function retrieves the authentication token for the Fabric API and sets up the headers for API calls.
+    Connects to the Fabric WebAPI by using the cmdlet Connect-AzAccount. This function retrieves the authentication token for the Fabric API and sets up the headers for API calls.
 
 .PARAMETER TenantId
-    The TenantId of the Azure Active Directory tenant you want to connect to
-    and in which your Fabric Capacity is.
+    The TenantId of the Azure Active Directory tenant you want to connect to and in which your Fabric Capacity is.
 
 .PARAMETER ServicePrincipalId
     The Client ID (AppId) of the service principal used for authentication.
 
 .PARAMETER ServicePrincipalSecret
-    The **secure string** representing the service principal secret. Use Read-Host -AsSecureString or other secure entry.
+    The **secure string** representing the service principal secret.
 
 .PARAMETER Credential
     A PSCredential object representing a user credential (username and secure password).
 
 .EXAMPLE
-    Connect-FabricAccount `
-        -TenantId '12345678-1234-1234-1234-123456789012'
+    Connect-FabricAccount -TenantId '12345678-1234-1234-1234-123456789012'
 
 .EXAMPLE
     $secret = Read-Host -AsSecureString
     Connect-FabricAccount -TenantId 'xxx' -ServicePrincipalId 'appId' -ServicePrincipalSecret $secret
-
 
 .NOTES
 
@@ -39,7 +35,6 @@ function Connect-FabricAccount {
 
 .LINK
     Connect-AzAccount https://learn.microsoft.com/de-de/powershell/module/az.accounts/connect-azaccount?view=azps-12.4.0
-
     #>
 
     [CmdletBinding(SupportsShouldProcess)]
@@ -66,7 +61,6 @@ function Connect-FabricAccount {
         if ($servicePrincipalId) {
             $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $servicePrincipalId, $servicePrincipalSecret
             $null = Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential
-            #Set-AzContext -Tenant $tenantId | Out-Null
         }
         elseif ($null -ne $credential) {
             $null = Connect-AzAccount -Credential $credential -Tenant $tenantId
@@ -88,8 +82,6 @@ function Connect-FabricAccount {
         $FabricSession.HeaderParams = @{'Authorization' = "Bearer {0}" -f $FabricSession.FabricToken }
         Write-Verbose "HeaderParams: $($FabricSession.HeaderParams)"
     }
-
     end {
     }
-
 }

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -77,18 +77,18 @@ function Connect-FabricAccount {
         else {
             $null = Connect-AzAccount
         }
-        
+
         $azContext = Get-AzContext
 
         Write-Verbose "Connected: $($azContext.Account)"
-        
+
         if ($PSCmdlet.ShouldProcess("Setting Fabric authentication token for $($azContext.Account)")) {
-            
+
             Write-Verbose "Get authentication token"
             $FabricSession.FabricToken = (Get-AzAccessToken -ResourceUrl $FabricSession.ResourceUrl).Token
             Write-Verbose "Token: $($FabricSession.FabricToken)"
             }
-            
+
          if ($PSCmdlet.ShouldProcess("Setting Fabric headers for $($azContext.Account)")) {
             Write-Verbose "Setup headers for API calls"
             $FabricSession.HeaderParams = @{'Authorization' = "Bearer {0}" -f $FabricSession.FabricToken }

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -65,7 +65,7 @@ function Connect-FabricAccount {
 
         if ($servicePrincipalId) {
             $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $servicePrincipalId, $servicePrincipalSecret
-            Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential | Out-Null
+            $null = Connect-AzAccount -ServicePrincipal -TenantId $tenantId -Credential $credential
             #Set-AzContext -Tenant $tenantId | Out-Null
         }
         elseif ($null -ne $credential) {

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -77,19 +77,23 @@ function Connect-FabricAccount {
         else {
             $null = Connect-AzAccount
         }
-
+        
         $azContext = Get-AzContext
+
+        Write-Verbose "Connected: $($azContext.Account)"
+        
         if ($PSCmdlet.ShouldProcess("Setting Fabric authentication token for $($azContext.Account)")) {
-            Write-output "Connected: $($azContext.Account)"
+            
+            Write-Verbose "Get authentication token"
+            $FabricSession.FabricToken = (Get-AzAccessToken -ResourceUrl $FabricSession.ResourceUrl).Token
+            Write-Verbose "Token: $($FabricSession.FabricToken)"
+            }
+            
+         if ($PSCmdlet.ShouldProcess("Setting Fabric headers for $($azContext.Account)")) {
+            Write-Verbose "Setup headers for API calls"
+            $FabricSession.HeaderParams = @{'Authorization' = "Bearer {0}" -f $FabricSession.FabricToken }
+            Write-Verbose "HeaderParams: $($FabricSession.HeaderParams)"
         }
-
-        Write-Verbose "Get authentication token"
-        $FabricSession.FabricToken = (Get-AzAccessToken -ResourceUrl $FabricSession.ResourceUrl).Token
-        Write-Verbose "Token: $($FabricSession.FabricToken)"
-
-        Write-Verbose "Setup headers for API calls"
-        $FabricSession.HeaderParams = @{'Authorization' = "Bearer {0}" -f $FabricSession.FabricToken }
-        Write-Verbose "HeaderParams: $($FabricSession.HeaderParams)"
     }
     end {
     }

--- a/source/Public/Connect-FabricAccount.ps1
+++ b/source/Public/Connect-FabricAccount.ps1
@@ -22,9 +22,18 @@ function Connect-FabricAccount {
 .EXAMPLE
     Connect-FabricAccount -TenantId '12345678-1234-1234-1234-123456789012'
 
+    Connects to the stated Tenant with exisitng credentials
+
 .EXAMPLE
-    $secret = Read-Host -AsSecureString
+    $credential = Get-Credential
+    Connect-FabricAccount -TenantId 'xxx' -credential $credential
+
+    Prompts for Service Principal id and secret and connects as that Service Principal
+
+.EXAMPLE
     Connect-FabricAccount -TenantId 'xxx' -ServicePrincipalId 'appId' -ServicePrincipalSecret $secret
+
+    Connects as Service Principal using id and secret
 
 .NOTES
 

--- a/tests/Unit/Connect-FabricAccount.Tests.ps1
+++ b/tests/Unit/Connect-FabricAccount.Tests.ps1
@@ -3,6 +3,9 @@ param(
     $ModuleName = "FabricTools",
     $expectedParams = @(
         "TenantId"
+        "ServicePrincipalId"
+        "ServicePrincipalSecret"
+        "Credential"
                 "Verbose"
                 "Debug"
                 "ErrorAction"
@@ -15,7 +18,9 @@ param(
                 "OutVariable"
                 "OutBuffer"
                 "PipelineVariable"
-                
+                "WhatIf"
+                "Confirm"
+
     )
 )
 
@@ -43,4 +48,3 @@ Describe "Connect-FabricAccount" -Tag "UnitTests" {
         }
     }
 }
-


### PR DESCRIPTION
Enhanced the Connect-FabricAccount function by adding support for Service Principal authentication. This includes new parameters for ServicePrincipalId, ServicePrincipalSecret, and Credential, allowing for more flexible authentication options. Updated the unit tests to reflect these changes and ensure proper validation.

Thank you!

# Pull Request

### Added
- support for SP autnetication [closes #61]

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [ ] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [ ] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
