### PR TITLE
Fix indentation and enable merge step for deployment

### DIFF
--- a/.github/workflows/deploy-module.yml
+++ b/.github/workflows/deploy-module.yml
@@ -59,7 +59,7 @@ jobs:
     name: Deploy Module
     runs-on: ubuntu-latest
     needs:
-     - Build_Stage_Package_Module
+      - Build_Stage_Package_Module
     if: ${{ success() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) }}
     steps:
     - name: Checkout Code
@@ -86,11 +86,11 @@ jobs:
         GalleryApiToken: ${{ secrets.GalleryApiToken }}
         ReleaseBranch: main
         MainGitBranch: main
-    #- name: Merge main -> develop
+    - name: Merge main -> develop
     # This step merges the main branch into the develop branch after a successful deployment. This ensures that the develop branch includes the tag for the latest release.
-    #  uses: devmasx/merge-branch@1.4.0
-    #  with:
-    #    type: now
-    #    from_branch: main
-    #    target_branch: develop
-    #    github_token: ${{ secrets.GitHubToken }}
+      uses: devmasx/merge-branch@1.4.0
+      with:
+        type: now
+        from_branch: main
+        target_branch: develop
+        github_token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
Corrected the indentation for the Build_Stage_Package_Module dependency and enabled the merge step to ensure the main branch is merged into develop after a successful deployment. This helps maintain the integrity of the develop branch with the latest release tags.

Thank you!

# Pull Request
