### PR TITLE
Fix for Update-FabricSemanticModelDefinition when platform file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug in `Update-FabricSemanticModelDefinition` - Uri was incorrect when a platform file exists
+
 ### Deprecated
 
 ### Removed

--- a/source/Public/Semantic Model/Update-FabricSemanticModelDefinition.ps1
+++ b/source/Public/Semantic Model/Update-FabricSemanticModelDefinition.ps1
@@ -74,7 +74,7 @@ function Update-FabricSemanticModelDefinition
 
         if ($hasPlatformFile -eq $true)
         {
-            $apiEndpointUrl = "?updateMetadata=true" -f $apiEndpointUrl
+            $apiEndpointUrl = "{0}?updateMetadata=true" -f $apiEndpointUrl
         }
         Write-Message -Message "API Endpoint: $apiEndpointUrl" -Level Debug
 


### PR DESCRIPTION
# Pull Request
 

## Pull Request (PR) description

Added a format placeholder when the URL is generated in Update-FabricSemanticModelDefinition.

### Fixed
- Fixed bug in `Update-FabricSemanticModelDefinition` - Uri was incorrect when a platform file exists


## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency -Tasks build, test`).
- [ ] Comment-based help added/updated.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated..
- [ ] Integration tests added/updated (where possible).
- [ ] Documentation added/updated (where applicable).
- [ ] Code follows the [contribution guidelines](https://github.com/dataplat/FabricTools/blob/develop/CONTRIBUTING.md).
