### PR TITLE
Add Id alias to WorkspaceId parameters for consistency #158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added `Id` parameter alias to Workspace functions that take `WorkspaceId` to support compatibility with API field names and issue #158.
+
 ### Deprecated
 
 ### Removed

--- a/source/Public/Workspace/Add-FabricWorkspaceCapacityAssignment.ps1
+++ b/source/Public/Workspace/Add-FabricWorkspaceCapacityAssignment.ps1
@@ -30,6 +30,7 @@ function Add-FabricWorkspaceCapacityAssignment {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $true)]

--- a/source/Public/Workspace/Add-FabricWorkspaceIdentity.ps1
+++ b/source/Public/Workspace/Add-FabricWorkspaceIdentity.ps1
@@ -26,6 +26,7 @@ function Add-FabricWorkspaceIdentity {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId
     )
 

--- a/source/Public/Workspace/Add-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Add-FabricWorkspaceRoleAssignment.ps1
@@ -36,6 +36,7 @@ function Add-FabricWorkspaceRoleAssignment {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $true)]

--- a/source/Public/Workspace/Get-FabricWorkspace.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspace.ps1
@@ -37,6 +37,7 @@ function Get-FabricWorkspace {
     param (
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $false)]

--- a/source/Public/Workspace/Get-FabricWorkspaceDatasetRefreshes.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceDatasetRefreshes.ps1
@@ -34,6 +34,7 @@ function Get-FabricWorkspaceDatasetRefreshes {
     param(
         # Define a mandatory parameter for the workspace ID
         [Parameter(Mandatory = $true)]
+        [Alias("Id")]
         [guid]$WorkspaceID
     )
 

--- a/source/Public/Workspace/Get-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceRoleAssignment.ps1
@@ -37,6 +37,7 @@ function Get-FabricWorkspaceRoleAssignment {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $false)]

--- a/source/Public/Workspace/Get-FabricWorkspaceUsageMetricsData.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceUsageMetricsData.ps1
@@ -32,6 +32,7 @@ Author: Ioana Bouariu
     # Define parameters for the workspace ID and username.
     param(
         [Parameter(Mandatory = $true)]
+        [Alias("Id")]
         [guid]$WorkspaceId,
         [Parameter(Mandatory = $false)]
         [string]$username = ""

--- a/source/Public/Workspace/Get-FabricWorkspaceUser.ps1
+++ b/source/Public/Workspace/Get-FabricWorkspaceUser.ps1
@@ -68,6 +68,7 @@ Author: Ioana Bouariu
     # Define parameters for the workspace ID and workspace object.
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceId')]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceObject', ValueFromPipeline = $true )]

--- a/source/Public/Workspace/New-FabricWorkspaceUsageMetricsReport.ps1
+++ b/source/Public/Workspace/New-FabricWorkspaceUsageMetricsReport.ps1
@@ -29,6 +29,7 @@ Author: Ioana Bouariu
     # Define a parameter for the workspace ID.
     param(
         [Parameter(Mandatory = $true)]
+        [Alias("Id")]
         [guid]$WorkspaceId
     )
 

--- a/source/Public/Workspace/Register-FabricWorkspaceToCapacity.ps1
+++ b/source/Public/Workspace/Register-FabricWorkspaceToCapacity.ps1
@@ -41,6 +41,7 @@ The ID of the capacity to which the workspace will be Seted. This is a mandatory
     param(
         # WorkspaceId is a mandatory parameter. It represents the ID of the workspace to be Seted.
         [Parameter(ParameterSetName = 'WorkspaceId')]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         # Workspace is a mandatory parameter. It represents the workspace object to be Seted.

--- a/source/Public/Workspace/Remove-FabricWorkspace.ps1
+++ b/source/Public/Workspace/Remove-FabricWorkspace.ps1
@@ -26,6 +26,7 @@ function Remove-FabricWorkspace {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId
     )
 

--- a/source/Public/Workspace/Remove-FabricWorkspaceCapacityAssignment.ps1
+++ b/source/Public/Workspace/Remove-FabricWorkspaceCapacityAssignment.ps1
@@ -28,6 +28,7 @@ function Remove-FabricWorkspaceCapacityAssignment
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId
     )
     try

--- a/source/Public/Workspace/Remove-FabricWorkspaceIdentity.ps1
+++ b/source/Public/Workspace/Remove-FabricWorkspaceIdentity.ps1
@@ -27,6 +27,7 @@ function Remove-FabricWorkspaceIdentity
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId
     )
 

--- a/source/Public/Workspace/Remove-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Remove-FabricWorkspaceRoleAssignment.ps1
@@ -30,6 +30,7 @@ function Remove-FabricWorkspaceRoleAssignment
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $true)]

--- a/source/Public/Workspace/Unregister-FabricWorkspaceToCapacity.ps1
+++ b/source/Public/Workspace/Unregister-FabricWorkspaceToCapacity.ps1
@@ -36,6 +36,7 @@ function Unregister-FabricWorkspaceToCapacity {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceId')]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'WorkspaceObject', ValueFromPipeline = $true)]

--- a/source/Public/Workspace/Update-FabricWorkspace.ps1
+++ b/source/Public/Workspace/Update-FabricWorkspace.ps1
@@ -40,6 +40,7 @@ function Update-FabricWorkspace
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $true)]

--- a/source/Public/Workspace/Update-FabricWorkspaceRoleAssignment.ps1
+++ b/source/Public/Workspace/Update-FabricWorkspaceRoleAssignment.ps1
@@ -37,6 +37,7 @@ function Update-FabricWorkspaceRoleAssignment
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
+        [Alias("Id")]
         [guid]$WorkspaceId,
 
         [Parameter(Mandatory = $true)]

--- a/tests/Unit/Add-FabricWorkspaceCapacityAssignment.Tests.ps1
+++ b/tests/Unit/Add-FabricWorkspaceCapacityAssignment.Tests.ps1
@@ -30,6 +30,13 @@ Describe "Add-FabricWorkspaceCapacityAssignment" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Add-FabricWorkspaceCapacityAssignment').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context 'When assigning capacity successfully (202)' {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { }

--- a/tests/Unit/Add-FabricWorkspaceIdentity.Tests.ps1
+++ b/tests/Unit/Add-FabricWorkspaceIdentity.Tests.ps1
@@ -29,6 +29,13 @@ Describe "Add-FabricWorkspaceIdentity" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Add-FabricWorkspaceIdentity').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context 'When provisioning identity successfully with immediate completion (200)' {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { }

--- a/tests/Unit/Add-FabricWorkspaceRoleAssignment.Tests.ps1
+++ b/tests/Unit/Add-FabricWorkspaceRoleAssignment.Tests.ps1
@@ -32,6 +32,13 @@ Describe "Add-FabricWorkspaceRoleAssignment" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Add-FabricWorkspaceRoleAssignment').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context 'When assigning role successfully (201)' {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { }

--- a/tests/Unit/Get-FabricWorkspace.Tests.ps1
+++ b/tests/Unit/Get-FabricWorkspace.Tests.ps1
@@ -30,6 +30,13 @@ Describe "Get-FabricWorkspace" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Get-FabricWorkspace').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context 'When retrieving workspaces successfully (200)' {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { }

--- a/tests/Unit/Get-FabricWorkspaceDatasetRefreshes.Tests.ps1
+++ b/tests/Unit/Get-FabricWorkspaceDatasetRefreshes.Tests.ps1
@@ -22,7 +22,12 @@ Describe "Get-FabricWorkspaceDatasetRefreshes" -Tag "UnitTests" {
             $Command | Should -HaveParameter -ParameterName $ExpectedParameterName -Type $ExpectedParameterType -Mandatory:([bool]::Parse($Mandatory))
         }
     }
-
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceID parameter' {
+            $param = (Get-Command -Name 'Get-FabricWorkspaceDatasetRefreshes').Parameters['WorkspaceID']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
     Context "Successful workspace dataset refreshes retrieval" -Skip {
         # Skipped: Function calls Get-FabricDataset which does not exist in the module
         BeforeAll {

--- a/tests/Unit/Get-FabricWorkspaceRoleAssignment.Tests.ps1
+++ b/tests/Unit/Get-FabricWorkspaceRoleAssignment.Tests.ps1
@@ -30,6 +30,13 @@ Describe "Get-FabricWorkspaceRoleAssignment" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Get-FabricWorkspaceRoleAssignment').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context 'When getting all workspace role assignments successfully' {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { }

--- a/tests/Unit/Get-FabricWorkspaceUsageMetricsData.Tests.ps1
+++ b/tests/Unit/Get-FabricWorkspaceUsageMetricsData.Tests.ps1
@@ -24,6 +24,13 @@ Describe "Get-FabricWorkspaceUsageMetricsData" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Get-FabricWorkspaceUsageMetricsData').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful workspace usage metrics data retrieval" {
         BeforeAll {
             Mock -CommandName New-FabricWorkspaceUsageMetricsReport -MockWith {

--- a/tests/Unit/Get-FabricWorkspaceUser.Tests.ps1
+++ b/tests/Unit/Get-FabricWorkspaceUser.Tests.ps1
@@ -30,6 +30,13 @@ Describe "Get-FabricWorkspaceUser" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Get-FabricWorkspaceUser').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Alias validation" {
         $testCases = @('Get-FabWorkspaceUsers', 'Get-FabricWorkspaceUsers')
 

--- a/tests/Unit/New-FabricWorkspaceUsageMetricsReport.Tests.ps1
+++ b/tests/Unit/New-FabricWorkspaceUsageMetricsReport.Tests.ps1
@@ -28,6 +28,13 @@ Describe "New-FabricWorkspaceUsageMetricsReport" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'New-FabricWorkspaceUsageMetricsReport').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful workspace usage metrics report creation" {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { return $true }

--- a/tests/Unit/Register-FabricWorkspaceToCapacity.Tests.ps1
+++ b/tests/Unit/Register-FabricWorkspaceToCapacity.Tests.ps1
@@ -30,6 +30,13 @@ Describe "Register-FabricWorkspaceToCapacity" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Register-FabricWorkspaceToCapacity').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful workspace registration" {
         BeforeAll {
             Mock -CommandName Invoke-FabricRestMethod -MockWith {

--- a/tests/Unit/Remove-FabricWorkspace.Tests.ps1
+++ b/tests/Unit/Remove-FabricWorkspace.Tests.ps1
@@ -34,6 +34,13 @@ Describe "Remove-FabricWorkspace" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Remove-FabricWorkspace').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context 'When removing workspace successfully (200)' {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { }

--- a/tests/Unit/Remove-FabricWorkspaceCapacityAssignment.Tests.ps1
+++ b/tests/Unit/Remove-FabricWorkspaceCapacityAssignment.Tests.ps1
@@ -28,6 +28,13 @@ Describe "Remove-FabricWorkspaceCapacityAssignment" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Remove-FabricWorkspaceCapacityAssignment').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful capacity assignment removal" {
         BeforeAll {
             Mock -CommandName Invoke-FabricRestMethod -MockWith {

--- a/tests/Unit/Remove-FabricWorkspaceIdentity.Tests.ps1
+++ b/tests/Unit/Remove-FabricWorkspaceIdentity.Tests.ps1
@@ -28,6 +28,13 @@ Describe "Remove-FabricWorkspaceIdentity" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Remove-FabricWorkspaceIdentity').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful workspace identity removal" {
         BeforeAll {
             Mock -CommandName Invoke-FabricRestMethod -MockWith {

--- a/tests/Unit/Remove-FabricWorkspaceRoleAssignment.Tests.ps1
+++ b/tests/Unit/Remove-FabricWorkspaceRoleAssignment.Tests.ps1
@@ -29,6 +29,13 @@ Describe "Remove-FabricWorkspaceRoleAssignment" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Remove-FabricWorkspaceRoleAssignment').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful workspace role assignment removal" {
         BeforeAll {
             Mock -CommandName Invoke-FabricRestMethod -MockWith {

--- a/tests/Unit/Unregister-FabricWorkspaceToCapacity.Tests.ps1
+++ b/tests/Unit/Unregister-FabricWorkspaceToCapacity.Tests.ps1
@@ -29,6 +29,13 @@ Describe "Unregister-FabricWorkspaceToCapacity" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Unregister-FabricWorkspaceToCapacity').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful workspace unregistration from capacity" {
         BeforeAll {
             Mock -CommandName Invoke-FabricRestMethod -MockWith {

--- a/tests/Unit/Update-FabricWorkspace.Tests.ps1
+++ b/tests/Unit/Update-FabricWorkspace.Tests.ps1
@@ -36,6 +36,13 @@ Describe "Update-FabricWorkspace" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Update-FabricWorkspace').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context 'When updating workspace successfully (200)' {
         BeforeAll {
             Mock -CommandName Confirm-TokenState -MockWith { }

--- a/tests/Unit/Update-FabricWorkspaceRoleAssignment.Tests.ps1
+++ b/tests/Unit/Update-FabricWorkspaceRoleAssignment.Tests.ps1
@@ -30,6 +30,13 @@ Describe "Update-FabricWorkspaceRoleAssignment" -Tag "UnitTests" {
         }
     }
 
+    Context 'Parameter alias validation' {
+        It 'Should have "Id" as an alias for WorkspaceId parameter' {
+            $param = (Get-Command -Name 'Update-FabricWorkspaceRoleAssignment').Parameters['WorkspaceId']
+            $param.Aliases | Should -Contain 'Id'
+        }
+    }
+
     Context "Successful workspace role assignment update" {
         BeforeAll {
             Mock -CommandName Invoke-FabricRestMethod -MockWith {


### PR DESCRIPTION
This change introduces an alias "Id" for the WorkspaceId parameter across multiple functions

# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
    
    PLEASE DO NOT submit PRs that contain multiple unrelated changes.
    If you have multiple changes, please submit them in separate PRs.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

    for example:

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency -Tasks build, test`).
- [x] Comment-based help added/updated.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated..
- [ ] Integration tests added/updated (where possible).
- [ ] Documentation added/updated (where applicable).
- [x] Code follows the [contribution guidelines](https://github.com/dataplat/FabricTools/blob/develop/CONTRIBUTING.md).
