### PR TITLE
Update New-FabricReport parameters for clarity #43

### DIFF
--- a/docs/en-US/New-FabricReport.md
+++ b/docs/en-US/New-FabricReport.md
@@ -21,7 +21,7 @@ Creates a new Report in a specified Microsoft Fabric workspace.
 
 ```
 New-FabricReport [-WorkspaceId] <guid> [-ReportName] <string> [[-ReportDescription] <string>]
- [-ReportPathDefinition] <string> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-ReportPathDefinition] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## ALIASES
@@ -111,7 +111,7 @@ HelpMessage: ''
 
 ### -ReportPathDefinition
 
-A mandatory path to the folder that contains Report definition files to upload.
+An optional path to the folder that contains Report definition files to upload.
 
 ```yaml
 Type: System.String
@@ -121,7 +121,7 @@ Aliases: []
 ParameterSets:
 - Name: (All)
   Position: 3
-  IsRequired: true
+  IsRequired: false
   ValueFromPipeline: false
   ValueFromPipelineByPropertyName: false
   ValueFromRemainingArguments: false
@@ -195,4 +195,3 @@ Author: Tiago Balabuch
 ## RELATED LINKS
 
 {{ Fill in the related links here }}
-

--- a/helper/build-and-test.ps1
+++ b/helper/build-and-test.ps1
@@ -15,7 +15,7 @@ Remove-Module -Name FabricTools -ErrorAction SilentlyContinue
 ipmo .\output\module\FabricTools\0.0.1\FabricTools.psd1
 Get-Module Fab*
 
-Invoke-ScriptAnalyzer -Path .\source\Public\**
+# Invoke-ScriptAnalyzer -Path .\source\Public\**
 
 
 $tests = Invoke-Pester .\tests\ -PassThru

--- a/source/Private/Test-FabricApiResponse.ps1
+++ b/source/Private/Test-FabricApiResponse.ps1
@@ -168,7 +168,7 @@ function Test-FabricApiResponse {
 
     # Try to get Name of Id from the response when new item is created
     if ($Operation -eq 'New' -and -not $ObjectIdOrName) {
-        $ObjectIdOrName = $Response.DisplayName ? $Response.DisplayName : $Response.id
+        $ObjectIdOrName = if ($Response.DisplayName) { $Response.DisplayName } else { $Response.id }
     }
     switch ($Operation) {
         'New'    { $msg = "$TypeName '$ObjectIdOrName' created successfully."; $level = 'Info' }

--- a/source/Public/Deployment Pipeline/Get-FabricDeploymentPipelineStage.ps1
+++ b/source/Public/Deployment Pipeline/Get-FabricDeploymentPipelineStage.ps1
@@ -70,7 +70,7 @@ Author: Kamil Nowinski
             HandleResponse = $true
             ExtractValue = $true
             TypeName = "deployment pipeline stage"
-            ObjectIdOrName = $StageId ? $StageId : $DeploymentPipelineId
+            ObjectIdOrName = if ($StageId) { $StageId } else { $DeploymentPipelineId }
         }
         $response = Invoke-FabricRestMethod @apiParameters
 

--- a/source/Public/Report/New-FabricReport.ps1
+++ b/source/Public/Report/New-FabricReport.ps1
@@ -18,7 +18,7 @@ function New-FabricReport
     An optional description for the Report.
 
 .PARAMETER ReportPathDefinition
-    A mandatory path to the folder that contains Report definition files to upload.
+    An optional path to the folder that contains Report definition files to upload.
 
 
 .EXAMPLE
@@ -49,7 +49,7 @@ function New-FabricReport
         [ValidateNotNullOrEmpty()]
         [string]$ReportDescription,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string]$ReportPathDefinition
     )


### PR DESCRIPTION
Changed ReportPathDefinition and ReportDescription parameters from mandatory to optional to enhance usability.

# Pull Request

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    TITLE: Please be descriptive not sensationalist.
    Also prepend with [BREAKING CHANGE] if relevant.
    i.e. [BREAKING CHANGE][xFile] Add security descriptor property

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
    Try to keep your PRs atomic: changes grouped in smallest batch affecting a single logical unit.
    
    PLEASE DO NOT submit PRs that contain multiple unrelated changes.
    If you have multiple changes, please submit them in separate PRs.
-->

## Pull Request (PR) description

<!--
    Replace this comment block with a description of your PR to provide context.
    Please be describe the intent and link issue where the problem has been discussed.
    try to link the issue that it fixes by providing the verb and ref: [fix|close #18]

    After the description, please concisely list the changes as per keepachangelog.com
    This **should** duplicate what you've updated in the changelog file.

    for example:

### Added
- for new features [closes #15]
### Changed
- for changes in existing functionality.
### Deprecated
- for soon-to-be removed features.
### Security
- in case of vulnerabilities.
### Fixed
- for any bug fixes. [fix #52]
### Removed
- for now removed features.
-->

## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency -Tasks build, test`).
- [x] Comment-based help added/updated.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated..
- [x] Integration tests added/updated (where possible).
- [x] Documentation added/updated (where applicable).
- [x] Code follows the [contribution guidelines](https://github.com/dataplat/FabricTools/blob/develop/CONTRIBUTING.md).
