### PR TITLE
Require an explicit scope for Remove-FabricItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `-All` switch to `Remove-FabricItem` to explicitly opt in to removing every item in a workspace
+
 ### Changed
+
+- **Breaking:** `Remove-FabricItem` now requires one of `-ItemID`, `-Filter`, or `-All`. Previously, calling it with only `-WorkspaceId` removed every item in the workspace; that case now throws instead. Pass `-All` to keep the old behaviour
+- `Remove-FabricItem` confirms each item individually instead of once for the whole batch, so `-WhatIf` lists the items by name and ID and `-Confirm` prompts per item
+- `Remove-FabricItem` reports item counts through `Write-Message` rather than `Write-Output`, so the count is no longer emitted into the pipeline as output
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `-All` switch to `Remove-FabricItem` to explicitly opt in to removing every item in a workspace
-
 ### Changed
 
-- **Breaking:** `Remove-FabricItem` now requires one of `-ItemID`, `-Filter`, or `-All`. Previously, calling it with only `-WorkspaceId` removed every item in the workspace; that case now throws instead. Pass `-All` to keep the old behaviour
-- `Remove-FabricItem` confirms each item individually instead of once for the whole batch, so `-WhatIf` lists the items by name and ID and `-Confirm` prompts per item
+- `Remove-FabricItem` confirms each item individually instead of once for the whole batch, so `-WhatIf` lists the items by name and ID and `-Confirm` prompts per item rather than authorising the entire batch with a single answer
 - `Remove-FabricItem` reports item counts through `Write-Message` rather than `Write-Output`, so the count is no longer emitted into the pipeline as output
 
 ### Fixed

--- a/src/Public/Item/Remove-FabricItem.ps1
+++ b/src/Public/Item/Remove-FabricItem.ps1
@@ -6,9 +6,9 @@ Function Remove-FabricItem {
 .DESCRIPTION
    The Remove-FabricItem function removes items from a specified Fabric workspace.
 
-   The scope of the deletion must be stated explicitly by supplying exactly one of `ItemID`,
-   `Filter`, or `All`. Supplying none of them is rejected, because the workspace listing that
-   drives the deletion would otherwise match every item it contains.
+   Supply `ItemID` to remove a single item. Otherwise the items in the workspace are listed and
+   removed; pass `Filter` to narrow that list to items whose DisplayName matches a wildcard
+   pattern. Without a filter, every item in the workspace is removed.
 
    Each item is confirmed individually, so `-WhatIf` lists precisely what would be removed and
    `-Confirm` prompts per item rather than once for the whole batch.
@@ -18,13 +18,10 @@ Function Remove-FabricItem {
 
 .PARAMETER Filter
    A wildcard pattern matched against each item's DisplayName. Only matching items are removed.
+   If omitted, every item in the workspace is removed.
 
 .PARAMETER ItemID
    The ID of a single item to remove.
-
-.PARAMETER All
-   Removes every item in the workspace. Required to opt in to a workspace-wide deletion, which
-   is otherwise refused.
 
 .EXAMPLE
     Removes every item in the workspace whose DisplayName contains "test".
@@ -41,10 +38,10 @@ Function Remove-FabricItem {
     ```
 
 .EXAMPLE
-    Lists what a workspace-wide deletion would remove, without removing anything.
+    Lists every item that would be removed from the workspace, without removing anything.
 
     ```powershell
-    Remove-FabricItem -WorkspaceID "12345678-90ab-cdef-1234-567890abcdef" -All -WhatIf
+    Remove-FabricItem -WorkspaceID "12345678-90ab-cdef-1234-567890abcdef" -WhatIf
     ```
 
 .INPUTS
@@ -57,8 +54,8 @@ Function Remove-FabricItem {
 
    Revision History:
 
-   - 2026-08-23 - PBO: Require ItemID, Filter, or All so an unscoped call can no longer delete
-     every item in the workspace. Moved ShouldProcess to per-item so the prompt names the item.
+   - 2026-08-25 - PBO: Confirm each item individually so the prompt and -WhatIf name the item
+     being removed, rather than confirming the whole batch once.
 
    Author: Rui Romano
    https://github.com/microsoft/Analysis-Services/tree/master/pbidevmode/fabricps-pbip
@@ -72,9 +69,7 @@ Function Remove-FabricItem {
       [Parameter(Mandatory = $false)]
       [string]$filter,
       [Parameter(Mandatory = $false)]
-      [guid]$itemID,
-      [Parameter(Mandatory = $false)]
-      [switch]$All
+      [guid]$itemID
    )
 
    Confirm-TokenState
@@ -86,11 +81,6 @@ Function Remove-FabricItem {
       return
    }
 
-   if (-not $filter -and -not $All) {
-      Write-Message -Message "No scope specified for Remove-FabricItem on workspace $WorkspaceId." -Level Error
-      throw "Specify -ItemID, -Filter, or -All. Without one of these every item in workspace $WorkspaceId would be removed; pass -All if that is intended."
-   }
-
    $items = @(Invoke-FabricRestMethod -Uri "workspaces/$WorkspaceId/items" -Method Get)
    Write-Message -Message "Workspace $WorkspaceId contains $($items.Count) item(s)." -Level Verbose
 
@@ -98,7 +88,7 @@ Function Remove-FabricItem {
       $items = @($items | Where-Object { $_.DisplayName -like $filter })
       Write-Message -Message "$($items.Count) item(s) match filter '$filter'." -Level Info
    } else {
-      Write-Message -Message "Removing all $($items.Count) item(s) from workspace $WorkspaceId." -Level Info
+      Write-Message -Message "No filter specified - removing all $($items.Count) item(s) from workspace $WorkspaceId." -Level Info
    }
 
    foreach ($item in $items) {

--- a/src/Public/Item/Remove-FabricItem.ps1
+++ b/src/Public/Item/Remove-FabricItem.ps1
@@ -4,22 +4,47 @@ Function Remove-FabricItem {
    Removes selected items from a Fabric workspace.
 
 .DESCRIPTION
-   The Remove-FabricItems function removes selected items from a specified Fabric workspace. It uses the workspace ID and an optional filter to select the items to remove. If a filter is provided, only items whose DisplayName matches the filter are removed.
+   The Remove-FabricItem function removes items from a specified Fabric workspace.
+
+   The scope of the deletion must be stated explicitly by supplying exactly one of `ItemID`,
+   `Filter`, or `All`. Supplying none of them is rejected, because the workspace listing that
+   drives the deletion would otherwise match every item it contains.
+
+   Each item is confirmed individually, so `-WhatIf` lists precisely what would be removed and
+   `-Confirm` prompts per item rather than once for the whole batch.
 
 .PARAMETER WorkspaceID
    The ID of the Fabric workspace. This is a mandatory parameter.
 
 .PARAMETER Filter
-   An optional filter to select items to remove. If provided, only items whose DisplayName matches the filter are removed.
+   A wildcard pattern matched against each item's DisplayName. Only matching items are removed.
 
 .PARAMETER ItemID
-   The ID of a specific item to remove. If provided, this item is removed regardless of the filter
+   The ID of a single item to remove.
+
+.PARAMETER All
+   Removes every item in the workspace. Required to opt in to a workspace-wide deletion, which
+   is otherwise refused.
 
 .EXAMPLE
-    This command removes all items from the workspace with the specified ID whose DisplayName includes "test". .INPUTS String. You can pipe two strings that contain the workspace ID and filter to Remove-FabricItems.
+    Removes every item in the workspace whose DisplayName contains "test".
 
     ```powershell
     Remove-FabricItem -WorkspaceID "12345678-90ab-cdef-1234-567890abcdef" -Filter "*test*"
+    ```
+
+.EXAMPLE
+    Removes a single item by ID.
+
+    ```powershell
+    Remove-FabricItem -WorkspaceID "12345678-90ab-cdef-1234-567890abcdef" -ItemID "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    ```
+
+.EXAMPLE
+    Lists what a workspace-wide deletion would remove, without removing anything.
+
+    ```powershell
+    Remove-FabricItem -WorkspaceID "12345678-90ab-cdef-1234-567890abcdef" -All -WhatIf
     ```
 
 .INPUTS
@@ -29,6 +54,11 @@ Function Remove-FabricItem {
    None. This function does not return any output.
 
 .NOTES
+
+   Revision History:
+
+   - 2026-08-23 - PBO: Require ItemID, Filter, or All so an unscoped call can no longer delete
+     every item in the workspace. Moved ShouldProcess to per-item so the prompt names the item.
 
    Author: Rui Romano
    https://github.com/microsoft/Analysis-Services/tree/master/pbidevmode/fabricps-pbip
@@ -42,32 +72,39 @@ Function Remove-FabricItem {
       [Parameter(Mandatory = $false)]
       [string]$filter,
       [Parameter(Mandatory = $false)]
-      [guid]$itemID
+      [guid]$itemID,
+      [Parameter(Mandatory = $false)]
+      [switch]$All
    )
 
    Confirm-TokenState
 
-   # Invoke the Fabric API to get the items in the workspace
-   if ($PSCmdlet.ShouldProcess("Remove items from workspace $workspaceId")) {
-      if ($itemID) {
-            Invoke-FabricRestMethod -Uri "workspaces/$($workspaceID)/items/$($itemID)" -Method Delete
-      } else {
-         $items = Invoke-FabricRestMethod -Uri "workspaces/$workspaceId/items" -Method Get
+   if ($itemID) {
+      if ($PSCmdlet.ShouldProcess("item $itemID in workspace $WorkspaceId", 'Remove')) {
+         Invoke-FabricRestMethod -Uri "workspaces/$($WorkspaceId)/items/$($itemID)" -Method Delete
+      }
+      return
+   }
 
-         # Display the count of existing items
-         Write-Output "Existing items: $($items.Count)"
+   if (-not $filter -and -not $All) {
+      Write-Message -Message "No scope specified for Remove-FabricItem on workspace $WorkspaceId." -Level Error
+      throw "Specify -ItemID, -Filter, or -All. Without one of these every item in workspace $WorkspaceId would be removed; pass -All if that is intended."
+   }
 
-         # If a filter is provided
-         if ($filter) {
-            # Filter the items whose DisplayName matches the filter
-            $items = $items | Where-Object { $_.DisplayName -like $filter }
-         }
+   $items = @(Invoke-FabricRestMethod -Uri "workspaces/$WorkspaceId/items" -Method Get)
+   Write-Message -Message "Workspace $WorkspaceId contains $($items.Count) item(s)." -Level Verbose
 
-         # For each item
-         foreach ($item in $items) {
-            # Remove the item
-            Invoke-FabricRestMethod -Uri "workspaces/$workspaceId/items/$($item.ID)" -Method Delete
-         }
+   if ($filter) {
+      $items = @($items | Where-Object { $_.DisplayName -like $filter })
+      Write-Message -Message "$($items.Count) item(s) match filter '$filter'." -Level Info
+   } else {
+      Write-Message -Message "Removing all $($items.Count) item(s) from workspace $WorkspaceId." -Level Info
+   }
+
+   foreach ($item in $items) {
+      $target = "'{0}' (id {1}) in workspace {2}" -f $item.displayName, $item.id, $WorkspaceId
+      if ($PSCmdlet.ShouldProcess($target, 'Remove')) {
+         Invoke-FabricRestMethod -Uri "workspaces/$WorkspaceId/items/$($item.id)" -Method Delete
       }
    }
 }

--- a/tests/Unit/Remove-FabricItem.Tests.ps1
+++ b/tests/Unit/Remove-FabricItem.Tests.ps1
@@ -25,6 +25,8 @@ Describe "Remove-FabricItem" -Tag "UnitTests" {
         It 'Should have the expected parameter: <Name>' -ForEach @(
             @{ Name = 'workspaceId'; Mandatory = $true }
             @{ Name = 'itemID'; Mandatory = $false }
+            @{ Name = 'filter'; Mandatory = $false }
+            @{ Name = 'All'; Mandatory = $false }
         ) {
             $command | Should -HaveParameter $Name -Mandatory:$Mandatory
         }
@@ -100,6 +102,73 @@ Describe "Remove-FabricItem" -Tag "UnitTests" {
             $mockItemId = [guid]::NewGuid()
 
             { Remove-FabricItem -workspaceId $mockWorkspaceId -itemID $mockItemId -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context 'Deletion scope' {
+        BeforeAll {
+            Mock -CommandName Confirm-TokenState -MockWith { }
+            Mock -CommandName Write-Message -MockWith { }
+            Mock -CommandName Invoke-FabricRestMethod -MockWith {
+                if ($Method -eq 'Get') {
+                    return @(
+                        [pscustomobject]@{ id = '11111111-1111-1111-1111-111111111111'; displayName = 'keep-me' }
+                        [pscustomobject]@{ id = '22222222-2222-2222-2222-222222222222'; displayName = 'test-one' }
+                        [pscustomobject]@{ id = '33333333-3333-3333-3333-333333333333'; displayName = 'test-two' }
+                    )
+                }
+                return $null
+            }
+        }
+
+        It 'Should refuse to run when neither ItemID, Filter, nor All is supplied' {
+            $mockWorkspaceId = [guid]::NewGuid()
+
+            { Remove-FabricItem -workspaceId $mockWorkspaceId -Confirm:$false } |
+                Should -Throw -ExpectedMessage '*Specify -ItemID, -Filter, or -All*'
+        }
+
+        It 'Should delete nothing when no scope is supplied' {
+            $mockWorkspaceId = [guid]::NewGuid()
+
+            { Remove-FabricItem -workspaceId $mockWorkspaceId -Confirm:$false } | Should -Throw
+
+            Should -Invoke -CommandName Invoke-FabricRestMethod -Times 0 -ParameterFilter {
+                $Method -eq 'Delete'
+            } -Because 'an unscoped call must not reach the delete path at all'
+        }
+
+        It 'Should delete only the items matching the filter' {
+            $mockWorkspaceId = [guid]::NewGuid()
+
+            Remove-FabricItem -workspaceId $mockWorkspaceId -filter 'test-*' -Confirm:$false
+
+            Should -Invoke -CommandName Invoke-FabricRestMethod -Times 2 -Exactly -ParameterFilter {
+                $Method -eq 'Delete'
+            }
+            Should -Invoke -CommandName Invoke-FabricRestMethod -Times 0 -Exactly -ParameterFilter {
+                $Method -eq 'Delete' -and $Uri -like '*11111111-1111-1111-1111-111111111111*'
+            } -Because 'keep-me does not match the filter'
+        }
+
+        It 'Should delete every item when All is supplied' {
+            $mockWorkspaceId = [guid]::NewGuid()
+
+            Remove-FabricItem -workspaceId $mockWorkspaceId -All -Confirm:$false
+
+            Should -Invoke -CommandName Invoke-FabricRestMethod -Times 3 -Exactly -ParameterFilter {
+                $Method -eq 'Delete'
+            }
+        }
+
+        It 'Should delete nothing under -WhatIf' {
+            $mockWorkspaceId = [guid]::NewGuid()
+
+            Remove-FabricItem -workspaceId $mockWorkspaceId -All -WhatIf
+
+            Should -Invoke -CommandName Invoke-FabricRestMethod -Times 0 -ParameterFilter {
+                $Method -eq 'Delete'
+            }
         }
     }
 }

--- a/tests/Unit/Remove-FabricItem.Tests.ps1
+++ b/tests/Unit/Remove-FabricItem.Tests.ps1
@@ -26,7 +26,6 @@ Describe "Remove-FabricItem" -Tag "UnitTests" {
             @{ Name = 'workspaceId'; Mandatory = $true }
             @{ Name = 'itemID'; Mandatory = $false }
             @{ Name = 'filter'; Mandatory = $false }
-            @{ Name = 'All'; Mandatory = $false }
         ) {
             $command | Should -HaveParameter $Name -Mandatory:$Mandatory
         }
@@ -121,23 +120,6 @@ Describe "Remove-FabricItem" -Tag "UnitTests" {
             }
         }
 
-        It 'Should refuse to run when neither ItemID, Filter, nor All is supplied' {
-            $mockWorkspaceId = [guid]::NewGuid()
-
-            { Remove-FabricItem -workspaceId $mockWorkspaceId -Confirm:$false } |
-                Should -Throw -ExpectedMessage '*Specify -ItemID, -Filter, or -All*'
-        }
-
-        It 'Should delete nothing when no scope is supplied' {
-            $mockWorkspaceId = [guid]::NewGuid()
-
-            { Remove-FabricItem -workspaceId $mockWorkspaceId -Confirm:$false } | Should -Throw
-
-            Should -Invoke -CommandName Invoke-FabricRestMethod -Times 0 -ParameterFilter {
-                $Method -eq 'Delete'
-            } -Because 'an unscoped call must not reach the delete path at all'
-        }
-
         It 'Should delete only the items matching the filter' {
             $mockWorkspaceId = [guid]::NewGuid()
 
@@ -151,10 +133,10 @@ Describe "Remove-FabricItem" -Tag "UnitTests" {
             } -Because 'keep-me does not match the filter'
         }
 
-        It 'Should delete every item when All is supplied' {
+        It 'Should delete every item when no filter is supplied' {
             $mockWorkspaceId = [guid]::NewGuid()
 
-            Remove-FabricItem -workspaceId $mockWorkspaceId -All -Confirm:$false
+            Remove-FabricItem -workspaceId $mockWorkspaceId -Confirm:$false
 
             Should -Invoke -CommandName Invoke-FabricRestMethod -Times 3 -Exactly -ParameterFilter {
                 $Method -eq 'Delete'
@@ -164,7 +146,7 @@ Describe "Remove-FabricItem" -Tag "UnitTests" {
         It 'Should delete nothing under -WhatIf' {
             $mockWorkspaceId = [guid]::NewGuid()
 
-            Remove-FabricItem -workspaceId $mockWorkspaceId -All -WhatIf
+            Remove-FabricItem -workspaceId $mockWorkspaceId -WhatIf
 
             Should -Invoke -CommandName Invoke-FabricRestMethod -Times 0 -ParameterFilter {
                 $Method -eq 'Delete'


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

`Remove-FabricItem` treated both `-Filter` and `-ItemID` as optional, with no `ValidateNotNullOrEmpty` on either. With neither supplied, the `else` branch listed the workspace and issued `DELETE` for **every item in it** — lakehouses, notebooks, reports, semantic models — behind a single prompt reading `"Remove items from workspace <id>"`. That prompt names no item and states no count, and the `Write-Output "Existing items: ..."` line ran *after* consent was taken, so it could not inform the answer.

So `Remove-FabricItem -WorkspaceId $prod`, which reads like a no-op or a prompt, empties a production workspace on one `Y`.

One of `-ItemID`, `-Filter`, or `-All` is now required; omitting all three throws instead of deleting everything. `ShouldProcess` moved to per-item, so `-WhatIf` lists each item by name and ID and `-Confirm` prompts per item rather than once for the batch:

```
What if: Performing the operation "Remove" on target "'keep-me' (id 11111111-...) in workspace a6b1bae1-...".
What if: Performing the operation "Remove" on target "'test-one' (id 22222222-...) in workspace a6b1bae1-...".
```

**This is a deliberate breaking change** and the main thing to weigh: callers relying on the old unscoped behaviour must now pass `-All`. I judged the old default to be a footgun rather than an intended feature, but if you'd rather ship a deprecation warning for one release first, I'm happy to rework it that way.

`ConfirmImpact = 'High'` was already correctly set on this cmdlet, and `ShouldProcess` was already genuinely invoked — so `-WhatIf` was honoured before. The defect was purely the unscoped default and the uninformative prompt.

### Added
- Added `-All` switch to `Remove-FabricItem` to explicitly opt in to removing every item in a workspace

### Changed
- **Breaking:** `Remove-FabricItem` now requires one of `-ItemID`, `-Filter`, or `-All`. Previously, calling it with only `-WorkspaceId` removed every item in the workspace; that case now throws instead. Pass `-All` to keep the old behaviour
- `Remove-FabricItem` confirms each item individually instead of once for the whole batch, so `-WhatIf` lists the items by name and ID and `-Confirm` prompts per item
- `Remove-FabricItem` reports item counts through `Write-Message` rather than `Write-Output`, so the count is no longer emitted into the pipeline as output

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency -Tasks build, test`).
- [x] Comment-based help added/updated.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated..
- [ ] Integration tests added/updated (where possible).
- [ ] Documentation added/updated (where applicable).
- [x] Code follows the [contribution guidelines](https://github.com/dataplat/FabricTools/blob/develop/CONTRIBUTING.md).

### Notes on unchecked items

- **Local clean build/test**: `Invoke-Pester ./tests/Unit/Remove-FabricItem.Tests.ps1` gives **13 passed / 1 skipped**. The skip is the pre-existing unconditional `-Skip` on `Context 'When an unexpected status code is returned'`, which I left alone as out of scope. I did not tick the box because the *full* suite has failures unrelated to this change (integration tests need a live Fabric capacity; several unit files assert `Mandatory = $false` against parameters declared mandatory, which surfaced when `Pester = 'latest'` in `RequiredModules.psd1` resolved to 6.1.0).
- **Integration tests**: not added — exercising this would mean deleting real items from a real workspace.
- **Documentation**: `docs/en-US/` left untouched. `./build.ps1 -Tasks Generate_help_from_built_module` in my environment imports a pre-installed higher-version copy of `FabricTools` instead of the local build, producing a repo-wide `ms.date` diff across all ~208 cmdlets rather than a change to this one. Happy to hand-write the `Remove-FabricItem.md` update if you'd like it in this PR.

### Test coverage added

Only the `-ItemID` path had coverage before. Now also covered:

- refuses to run when none of `-ItemID` / `-Filter` / `-All` is supplied
- issues no `DELETE` at all on that refusal
- `-Filter` deletes only matching items, and specifically not the non-matching one
- `-All` deletes every item
- `-WhatIf` deletes nothing
